### PR TITLE
Quenching model

### DIFF
--- a/diffmah/quenching_probability.py
+++ b/diffmah/quenching_probability.py
@@ -1,0 +1,461 @@
+"""Sigmoid-based models for quenching probabilities."""
+import numpy as np
+from collections import OrderedDict
+from jax import numpy as jax_np
+import jax
+
+from .utils import get_1d_arrays, jax_sigmoid
+
+
+__all__ = ("quenching_prob", "quenching_prob_cens", "quenching_prob_sats")
+
+
+DEFAULT_PARAM_VALUES = OrderedDict(
+    fq_cens_logm_crit=12.65,
+    fq_cens_k=10 ** 0.2,
+    fq_cens_ylo=0.15,
+    fq_cens_yhi=0.9,
+    fq_satboost_logmhost_crit=13,
+    fq_satboost_logmhost_k=10 ** 0.2,
+    fq_satboost_clusters=0.3,
+    fq_sat_delay_time=2,
+    fq_sat_tinfall_k=10 ** 0.5,
+)
+
+PARAM_BOUNDS = OrderedDict(
+    fq_cens_logm_crit=(11, 15),
+    fq_cens_k=(0, 2),
+    fq_cens_ylo=(0, 1),
+    fq_cens_yhi=(0, 1),
+    fq_satboost_logmhost_crit=(11, 15),
+    fq_satboost_logmhost_k=(0, 2),
+    fq_satboost_clusters=(0, 1),
+    fq_sat_delay_time=(0, 10),
+    fq_sat_tinfall_k=(0, 2),
+)
+
+
+def quenching_prob(
+    upid,
+    logmpeak,
+    logmhost,
+    time_since_infall,
+    fq_cens_logm_crit=None,
+    fq_cens_k=None,
+    fq_cens_ylo=None,
+    fq_cens_yhi=None,
+    fq_satboost_logmhost_crit=None,
+    fq_satboost_logmhost_k=None,
+    fq_satboost_clusters=None,
+    fq_sat_delay_time=None,
+    fq_sat_tinfall_k=None,
+):
+    """Probability that a galaxy is quenched.
+
+    Parameters
+    ----------
+    upid : float or ndarray of shape (nhalos, )
+        The ID of the parent halo of a (sub)halo. Should be -1 to indicate a
+        (sub)halo has no parents.
+    logmpeak : ndarray, shape (nhalos, )
+        Base-10 log of peak (sub)halo mass
+    logmhost : ndarray, shape (nhalos, )
+        Base-10 log of host halo mass
+    time_since_infall : float or ndarray of shape (nhalos, )
+        Time since infall for satellites.
+    fq_cens_logm_crit : float, optional
+        Value of log10(Mhalo) of the inflection point of qprob
+    fq_cens_k : float, optional
+        steepness of the sigmoid
+    fq_cens_ylo : float, optional
+        Quenched fraction of dwarf-mass centrals
+    fq_cens_yhi : float, optional
+        Quenched fraction of cluster-mass centrals
+    fq_satboost_logmhost_crit : float, optional
+        Value of log10(mhost) of the inflection point
+        of the satellite quenching boost
+    fq_satboost_logmhost_k : float, optional
+        steepness of the sigmoid controlling the satellite quenching boost
+    fq_satboost_clusters : float, optional
+        Boost to quenched fraction of satellites of cluster-mass halos
+    fq_sat_delay_time : float, optional
+        Time after infall (in Gyr) when satellite-specific quenching begins
+    fq_sat_tinfall_k : float, optional
+        Steepness of the sigmoid function controlling how rapidly
+        satellite-specific transition to becoming quenched
+
+    Returns
+    -------
+    qprob : ndarray, shape (nhalos, )
+        Probability of an object being quenched.
+    """
+    upid, logmpeak, logmhost, time_since_infall = get_1d_arrays(
+        upid, logmpeak, logmhost, time_since_infall
+    )
+
+    fq_cens_logm_crit = (
+        DEFAULT_PARAM_VALUES["fq_cens_logm_crit"]
+        if fq_cens_logm_crit is None
+        else fq_cens_logm_crit
+    )
+    fq_cens_k = DEFAULT_PARAM_VALUES["fq_cens_k"] if fq_cens_k is None else fq_cens_k
+    fq_cens_ylo = (
+        DEFAULT_PARAM_VALUES["fq_cens_ylo"] if fq_cens_ylo is None else fq_cens_ylo
+    )
+    fq_cens_yhi = (
+        DEFAULT_PARAM_VALUES["fq_cens_yhi"] if fq_cens_yhi is None else fq_cens_yhi
+    )
+
+    fq_satboost_logmhost_crit = (
+        DEFAULT_PARAM_VALUES["fq_satboost_logmhost_crit"]
+        if fq_satboost_logmhost_crit is None
+        else fq_satboost_logmhost_crit
+    )
+    fq_satboost_logmhost_k = (
+        DEFAULT_PARAM_VALUES["fq_satboost_logmhost_k"]
+        if fq_satboost_logmhost_k is None
+        else fq_satboost_logmhost_k
+    )
+    fq_satboost_clusters = (
+        DEFAULT_PARAM_VALUES["fq_satboost_clusters"]
+        if fq_satboost_clusters is None
+        else fq_satboost_clusters
+    )
+    fq_sat_delay_time = (
+        DEFAULT_PARAM_VALUES["fq_sat_delay_time"]
+        if fq_sat_delay_time is None
+        else fq_sat_delay_time
+    )
+    fq_sat_tinfall_k = (
+        DEFAULT_PARAM_VALUES["fq_sat_tinfall_k"]
+        if fq_sat_tinfall_k is None
+        else fq_sat_tinfall_k
+    )
+
+    params = np.array(
+        [
+            fq_cens_logm_crit,
+            fq_cens_k,
+            fq_cens_ylo,
+            fq_cens_yhi,
+            fq_satboost_logmhost_crit,
+            fq_satboost_logmhost_k,
+            fq_satboost_clusters,
+            fq_sat_delay_time,
+            fq_sat_tinfall_k,
+        ]
+    )
+    return np.asarray(
+        quenching_prob_jax(upid, logmpeak, logmhost, time_since_infall, params)
+    )
+
+
+def _quenching_prob_jax_kern(upid, logmpeak, logmhost, time_since_infall, params):
+    """Probability that a galaxy is quenched.
+
+    Parameters
+    ----------
+    upid : float or ndarray of shape (nhalos, )
+        The ID of the parent halo of a (sub)halo. Should be -1 to indicate a
+        (sub)halo has no parents.
+    logmpeak : ndarray, shape (nhalos, )
+        Base-10 log of peak (sub)halo mass
+    logmhost : ndarray, shape (nhalos, )
+        Base-10 log of host halo mass
+    time_since_infall : float or ndarray of shape (nhalos, )
+        Time since infall for satellites.
+    params : array, shape (9,)
+        An array with the parameters
+
+            fq_cens_logm_crit
+            fq_cens_k
+            fq_cens_ylo
+            fq_cens_yhi
+            fq_satboost_logmhost_crit
+            fq_satboost_logmhost_k
+            fq_satboost_clusters
+            fq_sat_delay_time
+            fq_sat_tinfall_k
+
+        See the documentation of the function `quenching_prob` for
+        their definitions.
+
+    Returns
+    -------
+    qprob : ndarray, shape (nhalos, )
+        Probability of an object being quenched.
+    """
+    return jax_np.where(
+        upid == -1,
+        # centrals
+        _quenching_prob_cens_jax_kern(logmpeak, params),
+        # sats
+        _quenching_prob_sats_jax_kern(logmpeak, logmhost, time_since_infall, params),
+    )
+
+
+quenching_prob_jax = jax.jit(
+    jax.vmap(_quenching_prob_jax_kern, in_axes=(0, 0, 0, 0, None))
+)
+quenching_prob_jax.__doc__ = _quenching_prob_jax_kern.__doc__
+
+
+def quenching_prob_cens(
+    logmhalo,
+    fq_cens_logm_crit=None,
+    fq_cens_k=None,
+    fq_cens_ylo=None,
+    fq_cens_yhi=None,
+):
+    """Probability that a central galaxy is quenched.
+
+    Parameters
+    ----------
+    logmhalo : ndarray, shape (nhalos, )
+        Base-10 log of host halo mass
+    fq_cens_logm_crit : float, optional
+        Value of log10(Mhalo) of the inflection point of qprob
+    fq_cens_k : float, optional
+        steepness of the sigmoid
+    fq_cens_ylo : float, optional
+        Quenched fraction of dwarf-mass centrals
+    fq_cens_yhi : float, optional
+        Quenched fraction of cluster-mass centrals
+
+    Returns
+    -------
+    qprob : ndarray
+        Numpy array of shape (nhalos, )
+
+    """
+    (logmhalo,) = get_1d_arrays(logmhalo)
+
+    fq_cens_logm_crit = (
+        DEFAULT_PARAM_VALUES["fq_cens_logm_crit"]
+        if fq_cens_logm_crit is None
+        else fq_cens_logm_crit
+    )
+    fq_cens_k = DEFAULT_PARAM_VALUES["fq_cens_k"] if fq_cens_k is None else fq_cens_k
+    fq_cens_ylo = (
+        DEFAULT_PARAM_VALUES["fq_cens_ylo"] if fq_cens_ylo is None else fq_cens_ylo
+    )
+    fq_cens_yhi = (
+        DEFAULT_PARAM_VALUES["fq_cens_yhi"] if fq_cens_yhi is None else fq_cens_yhi
+    )
+
+    params = np.array([fq_cens_logm_crit, fq_cens_k, fq_cens_ylo, fq_cens_yhi])
+
+    return np.asarray(quenching_prob_cens_jax(logmhalo, params))
+
+
+def _quenching_prob_cens_jax_kern(logmhalo, params):
+    """Quenching probability for centrals.
+
+    Parameters
+    ----------
+    logmhalo : ndarray of shape (nhalos,)
+        Base-10 log of host halo mass
+    params : array-like, shape (4,)
+        An array with the parameters
+
+            fq_cens_logm_crit
+            fq_cens_k
+            fq_cens_ylo
+            fq_cens_yhi
+
+        See the documentation of the function `quenching_prob` for
+        their definitions.
+
+    Returns
+    -------
+    qprob : ndarray of shape (nhalos,)
+        The probability that a given (sub)halo has been quenched.
+    """
+    x0 = params[0]  # fq_cens_logm_crit
+    k = params[1]  # fq_cens_k
+    ylo = params[2]  # fq_cens_ylo
+    yhi = params[3]  # fq_cens_yhi
+    return jax_sigmoid(logmhalo, x0, k, ylo, yhi)
+
+
+quenching_prob_cens_jax = jax.jit(
+    jax.vmap(_quenching_prob_cens_jax_kern, in_axes=(0, None))
+)
+quenching_prob_cens_jax.__doc__ = _quenching_prob_cens_jax_kern.__doc__
+
+
+def quenching_prob_sats(
+    logmpeak,
+    logmhost,
+    time_since_infall,
+    fq_cens_logm_crit=None,
+    fq_cens_k=None,
+    fq_cens_ylo=None,
+    fq_cens_yhi=None,
+    fq_satboost_logmhost_crit=None,
+    fq_satboost_logmhost_k=None,
+    fq_satboost_clusters=None,
+    fq_sat_delay_time=None,
+    fq_sat_tinfall_k=None,
+):
+    """Probability that a satellite galaxy is quenched.
+
+    Parameters
+    ----------
+    logmpeak : ndarray, shape (nhalos, )
+        Base-10 log of peak (sub)halo mass
+    logmhost : ndarray, shape (nhalos, )
+        Base-10 log of host halo mass
+    time_since_infall : float or ndarray of shape (nhalos, )
+        Time since infall for satellites.
+    fq_cens_logm_crit : float, optional
+        Value of log10(Mhalo) of the inflection point of qprob
+    fq_cens_k : float, optional
+        steepness of the sigmoid
+    fq_cens_ylo : float, optional
+        Quenched fraction of dwarf-mass centrals
+    fq_cens_yhi : float, optional
+        Quenched fraction of cluster-mass centrals
+    fq_satboost_logmhost_crit : float, optional
+        Value of log10(mhost) of the inflection point
+        of the satellite quenching boost
+    fq_satboost_logmhost_k : float, optional
+        steepness of the sigmoid controlling the satellite quenching boost
+    fq_satboost_clusters : float, optional
+        Boost to quenched fraction of satellites of cluster-mass halos
+    fq_sat_delay_time : float, optional
+        Time after infall (in Gyr) when satellite-specific quenching begins
+    fq_sat_tinfall_k : float, optional
+        steepness of the sigmoid function controlling how rapidly
+        satellite-specific transition to becoming quenched
+
+    Returns
+    -------
+    qprob : ndarray, shape (nhalos, )
+        Probability of an object being quenched.
+    """
+    logmpeak, logmhost, time_since_infall = get_1d_arrays(
+        logmpeak, logmhost, time_since_infall
+    )
+
+    fq_cens_logm_crit = (
+        DEFAULT_PARAM_VALUES["fq_cens_logm_crit"]
+        if fq_cens_logm_crit is None
+        else fq_cens_logm_crit
+    )
+    fq_cens_k = DEFAULT_PARAM_VALUES["fq_cens_k"] if fq_cens_k is None else fq_cens_k
+    fq_cens_ylo = (
+        DEFAULT_PARAM_VALUES["fq_cens_ylo"] if fq_cens_ylo is None else fq_cens_ylo
+    )
+    fq_cens_yhi = (
+        DEFAULT_PARAM_VALUES["fq_cens_yhi"] if fq_cens_yhi is None else fq_cens_yhi
+    )
+
+    fq_satboost_logmhost_crit = (
+        DEFAULT_PARAM_VALUES["fq_satboost_logmhost_crit"]
+        if fq_satboost_logmhost_crit is None
+        else fq_satboost_logmhost_crit
+    )
+    fq_satboost_logmhost_k = (
+        DEFAULT_PARAM_VALUES["fq_satboost_logmhost_k"]
+        if fq_satboost_logmhost_k is None
+        else fq_satboost_logmhost_k
+    )
+    fq_satboost_clusters = (
+        DEFAULT_PARAM_VALUES["fq_satboost_clusters"]
+        if fq_satboost_clusters is None
+        else fq_satboost_clusters
+    )
+    fq_sat_delay_time = (
+        DEFAULT_PARAM_VALUES["fq_sat_delay_time"]
+        if fq_sat_delay_time is None
+        else fq_sat_delay_time
+    )
+    fq_sat_tinfall_k = (
+        DEFAULT_PARAM_VALUES["fq_sat_tinfall_k"]
+        if fq_sat_tinfall_k is None
+        else fq_sat_tinfall_k
+    )
+
+    params = np.array(
+        [
+            fq_cens_logm_crit,
+            fq_cens_k,
+            fq_cens_ylo,
+            fq_cens_yhi,
+            fq_satboost_logmhost_crit,
+            fq_satboost_logmhost_k,
+            fq_satboost_clusters,
+            fq_sat_delay_time,
+            fq_sat_tinfall_k,
+        ]
+    )
+    return np.asarray(
+        quenching_prob_sats_jax(logmpeak, logmhost, time_since_infall, params)
+    )
+
+
+def _quenching_prob_sats_jax_kern(logmpeak, logmhost, time_since_infall, params):
+    """Probability that a satellite galaxy is quenched.
+
+    Parameters
+    ----------
+    logmpeak : ndarray, shape (nhalos, )
+        Base-10 log of peak (sub)halo mass
+    logmhost : ndarray, shape (nhalos, )
+        Base-10 log of host halo mass
+    time_since_infall : float or ndarray of shape (nhalos, )
+        Time since infall for satellites.
+    params : array, shape (9,)
+        An array with the parameters
+
+            fq_cens_logm_crit
+            fq_cens_k
+            fq_cens_ylo
+            fq_cens_yhi
+            fq_satboost_logmhost_crit
+            fq_satboost_logmhost_k
+            fq_satboost_clusters
+            fq_sat_delay_time
+            fq_sat_tinfall_k
+
+        See the documentation of the function `quenching_prob` for
+        their definitions.
+
+    Returns
+    -------
+    qprob : ndarray, shape (nhalos, )
+        Probability of an object being quenched.
+    """
+
+    qprob_cens = _quenching_prob_cens_jax_kern(logmpeak, params[:4])
+
+    qprob_boost_sats_limit = _quenching_prob_boost_sats_jax_kern(
+        logmpeak, logmhost, params,
+    )
+
+    qprob_satboost_infall_factor = _qprob_sat_infall_dependence_jax_kern(
+        time_since_infall, params,
+    )
+
+    qprob_boost_sats = qprob_boost_sats_limit * qprob_satboost_infall_factor
+
+    return qprob_cens + (1 - qprob_cens) * qprob_boost_sats
+
+
+quenching_prob_sats_jax = jax.jit(
+    jax.vmap(_quenching_prob_sats_jax_kern, in_axes=(0, 0, 0, None))
+)
+quenching_prob_sats_jax.__doc__ = _quenching_prob_sats_jax_kern.__doc__
+
+
+def _quenching_prob_boost_sats_jax_kern(logm, logmhost, params):
+    x0, k = params[4], params[5]
+    ylo, yhi = 0, params[6]
+    return jax_sigmoid(logmhost, x0, k, ylo, yhi)
+
+
+def _qprob_sat_infall_dependence_jax_kern(time_since_infall, params):
+    x0, k = params[7], params[8]
+    ylo, yhi = 0, 1
+    return jax_sigmoid(time_since_infall, x0, k, ylo, yhi)

--- a/diffmah/quenching_times.py
+++ b/diffmah/quenching_times.py
@@ -1,0 +1,167 @@
+"""Model for the quenching time of central galaxies."""
+import numpy as np
+from collections import OrderedDict
+from jax import numpy as jax_np
+from jax.scipy.special import erfinv as jax_erfinv
+from jax import jit as jax_jit
+from jax import vmap as jax_vmap
+
+
+DEFAULT_PARAMS = OrderedDict(
+    qt_lgmc=12.25,
+    qt_k=1.5,
+    qt_dwarfs=15,
+    qt_clusters=1,
+    qt_scatter_lgmc=12.5,
+    qt_scatter_k=1,
+    qt_scatter_dwarfs=0.1,
+    qt_scatter_clusters=0.4,
+)
+
+
+def central_quenching_time(logm0, percentile, **kwargs):
+    """Quenching time of central galaxies.
+
+    In this model, the quenching time decreases with increasing mass,
+    such that massive BCGs have earlier quenching times relative to
+    centrals of Milky Way mass halos.
+
+    Parameters
+    ----------
+    logm0 : float or ndarray of shape (n, )
+        Base-10 log of halo mass at z=0
+
+    percentile : float or ndarray of shape (n, )
+        percentile = Prob(< y | logm0) for some halo property y.
+        For the median quenching time use percentile = 0.5.
+
+    qt_lgmc : float or ndarray, optional
+        Value of log10(Mhalo) of the inflection point of qtime
+
+    qt_k : float or ndarray, optional
+        Steepness of the qtime sigmoid
+
+    qt_dwarfs : float or ndarray, optional
+        Quenching time of dwarf-mass centrals
+
+    qt_clusters : float or ndarray, optional
+        Quenching time of cluster-mass centrals
+
+    qt_scatter_lgmc : float or ndarray, optional
+        Value of log10(Mhalo) of the inflection point of qtime scatter
+
+    qt_scatter_k : float or ndarray, optional
+        Steepness of the qtime scatter sigmoid
+
+    qt_scatter_dwarfs : float or ndarray, optional
+        Quenching time scatter in dwarf-mass centrals
+
+    qt_scatter_clusters : float or ndarray, optional
+        Quenching time scatter in cluster-mass centrals
+
+    Returns
+    -------
+    qtime : float or ndarray of shape (n, )
+        Age of the universe at the time of quenching in units of Gyr
+
+    """
+    logm0, percentile = _get_1d_arrays(logm0, percentile)
+    param_dict = _get_default_quenching_time_param_dict(**kwargs)
+    params = tuple(param_dict.values())
+    qtime = central_quenching_time_jax(logm0, percentile, params)
+    return np.asarray(qtime)
+
+
+def _central_quenching_time_kern(logm0, percentile, params):
+    qt_params, qt_scatter_params = params[0:4], params[4:]
+    logtq_med = jax_np.log10(_median_quenching_time_kern(logm0, qt_params))
+    logtq_scale = _quenching_time_scatter_kern(logm0, qt_scatter_params)
+    ylo, yhi = logtq_med - logtq_scale, logtq_med + logtq_scale
+    z = _z_score_from_percentile(percentile)
+    log_qt = _jax_sigmoid(z, 0, 1, ylo, yhi)
+    return jax_np.power(10, log_qt)
+
+
+central_quenching_time_jax = jax_jit(
+    jax_vmap(_central_quenching_time_kern, in_axes=(0, 0, None))
+)
+
+
+def satellite_quenching_time(logm0, percentile, infall_time, **kwargs):
+    """Quenching time of satellite galaxies.
+
+    Minimum of infall time and the corresponding central_quenching_time.
+
+    """
+    qtime_cens = central_quenching_time(logm0, percentile, **kwargs)
+    return jax_np.minimum(qtime_cens, infall_time)
+
+
+def _median_quenching_time_kern(logm0, params):
+    qt_lgmc, qt_k, qt_dwarfs, qt_clusters = params
+    return _jax_sigmoid(logm0, qt_lgmc, qt_k, qt_dwarfs, qt_clusters)
+
+
+def _quenching_time_scatter_kern(logm0, params):
+    qt_scatter_lgmc, qt_scatter_k, qt_scatter_dwarfs, qt_scatter_clusters = params
+    return _jax_sigmoid(
+        logm0, qt_scatter_lgmc, qt_scatter_k, qt_scatter_dwarfs, qt_scatter_clusters
+    )
+
+
+median_quenching_time_jax = jax_jit(
+    jax_vmap(_median_quenching_time_kern, in_axes=(0, None))
+)
+
+quenching_time_scatter_jax = jax_jit(
+    jax_vmap(_quenching_time_scatter_kern, in_axes=(0, None))
+)
+
+
+@jax_jit
+def _z_score_from_percentile(percentile):
+    return jax_np.sqrt(2) * jax_erfinv(2 * percentile - 1)
+
+
+@jax_jit
+def _weighted_mixture_of_two_gaussians(g1, g2, r):
+    return r * g1 + jax_np.sqrt(1 - r * r) * g2
+
+
+@jax_jit
+def _jax_sigmoid(x, x0, k, ymin, ymax):
+    height_diff = ymax - ymin
+    return ymin + height_diff / (1 + jax_np.exp(-k * (x - x0)))
+
+
+def _get_1d_arrays(*args):
+    """Return a list of ndarrays of the same length."""
+    results = [np.atleast_1d(arg) for arg in args]
+    sizes = [arr.size for arr in results]
+    npts = max(sizes)
+    msg = "All input arguments should be either a float or ndarray of shape ({0}, )"
+    assert set(sizes) <= set((1, npts)), msg.format(npts)
+    return [np.zeros(npts).astype(arr.dtype) + arr for arr in results]
+
+
+def _enforce_no_extraneous_keywords(**kwargs):
+    unrecognized_params = set(kwargs) - set(DEFAULT_PARAMS)
+
+    if len(unrecognized_params) > 0:
+        param = list(unrecognized_params)[0]
+        msg = (
+            "Unrecognized parameter ``{0}``"
+            " passed to central_quenching_time function"
+        )
+        raise KeyError(msg.format(param))
+
+
+def _get_default_quenching_time_param_dict(**kwargs):
+    """
+    """
+    _enforce_no_extraneous_keywords(**kwargs)
+
+    param_dict = OrderedDict()
+    for key, default_value in DEFAULT_PARAMS.items():
+        param_dict[key] = kwargs.get(key, default_value)
+    return param_dict

--- a/diffmah/tests/test_quenching_probability.py
+++ b/diffmah/tests/test_quenching_probability.py
@@ -1,0 +1,63 @@
+"""Testing functions of the sigmoid-based quenching probability."""
+import numpy as np
+import pytest
+
+from ..quenching_probability import (
+    quenching_prob_cens,
+    quenching_prob_sats,
+    quenching_prob,
+)
+
+NPTS = 4
+LOGMHALO = np.linspace(9, 16, NPTS)
+QPROB_CENS = np.array([0.15229824, 0.23279159, 0.77519469, 0.89630955])
+LOGMPEAK = np.linspace(8, 14, NPTS)
+LOGMHOST = np.linspace(11, 17, NPTS)
+TINF = np.linspace(-1, 10, NPTS)
+QPROB_SATS = np.array([0.150473, 0.27329003, 0.53520561, 0.87461947])
+
+
+def test_sigmoid_quenching_cens_regression():
+    qprob_cens = quenching_prob_cens(LOGMHALO)
+    assert np.all(qprob_cens >= 0)
+    assert np.all(qprob_cens <= 1)
+
+    assert np.any(qprob_cens > 0)
+    assert np.any(qprob_cens < 1)
+
+    assert np.allclose(qprob_cens, QPROB_CENS)
+
+
+def test_sigmoid_quenching_cens_params():
+    qprob_cens = quenching_prob_cens(LOGMHALO)
+    qprob_cens2 = quenching_prob_cens(LOGMHALO, fq_cens_logm_crit=11.1)
+    assert ~np.allclose(qprob_cens, qprob_cens2)
+
+
+def test_sigmoid_quenching_sats_regression():
+    qprob_sats = quenching_prob_sats(LOGMPEAK, LOGMHOST, TINF)
+    assert np.all(qprob_sats >= 0)
+    assert np.all(qprob_sats <= 1)
+
+    assert np.any(qprob_sats > 0)
+    assert np.any(qprob_sats < 1)
+
+    assert np.allclose(qprob_sats, QPROB_SATS)
+
+
+def test_sigmoid_quenching_sats_params():
+    qrob_sats = quenching_prob_sats(LOGMPEAK, LOGMHOST, TINF)
+    qrob_sats2 = quenching_prob_sats(LOGMPEAK, LOGMHOST, TINF, fq_sat_delay_time=3)
+    assert not np.all(qrob_sats == qrob_sats2)
+
+
+def test_sigmoid_quenching_qprob_satcen_consistent():
+    """Enforce function responds to its parameters."""
+
+    qprob1 = quenching_prob(-1, LOGMPEAK, LOGMHOST, TINF)
+    qprob_cens = quenching_prob_cens(LOGMPEAK)
+    assert np.allclose(qprob1, qprob_cens)
+
+    qprob2 = quenching_prob(1, LOGMPEAK, LOGMHOST, TINF)
+    qrob_sats = quenching_prob_sats(LOGMPEAK, LOGMHOST, TINF)
+    assert np.allclose(qprob2, qrob_sats)

--- a/diffmah/tests/test_quenching_times.py
+++ b/diffmah/tests/test_quenching_times.py
@@ -1,0 +1,20 @@
+"""
+"""
+import numpy as np
+from ..quenching_times import central_quenching_time, satellite_quenching_time
+
+
+def test_central_qtime_is_monotonic():
+    logm0 = np.linspace(10, 15, 1000)
+    qtimes0 = central_quenching_time(logm0, 0.5)
+    qtimes1 = central_quenching_time(logm0, np.zeros_like(logm0) + 0.5)
+    assert np.allclose(qtimes0, qtimes1)
+    assert np.all(np.diff(qtimes0) <= 0)
+
+
+def test_satellite_qtime_is_earlier_than_central_qtime():
+    logm0 = np.linspace(10, 15, 1000)
+    qtimes0 = central_quenching_time(logm0, 0.5)
+    inftime = np.random.uniform(0, 14, 1000)
+    qtimes1 = satellite_quenching_time(logm0, np.zeros_like(logm0) + 0.5, inftime)
+    assert np.all(qtimes1 <= qtimes0)

--- a/diffmah/utils.py
+++ b/diffmah/utils.py
@@ -1,0 +1,39 @@
+import numpy as np
+from jax import numpy as jax_np
+
+
+def get_1d_arrays(*args):
+    """Return a list of ndarrays of the same length.
+
+    Each arg must be either an ndarray of shape (npts, ), or a scalar.
+
+    """
+    results = [np.atleast_1d(arg) for arg in args]
+    sizes = [arr.size for arr in results]
+    npts = max(sizes)
+    msg = "All input arguments should be either a float or ndarray of shape ({0}, )"
+    assert set(sizes) <= set((1, npts)), msg.format(npts)
+    return [np.zeros(npts).astype(arr.dtype) + arr for arr in results]
+
+
+def jax_sigmoid(x, x0, k, ylo, yhi):
+    """Sigmoid function implemented w/ `jax.numpy.exp`.
+
+    Parameters
+    ----------
+    x : float or array-like
+        Points at which to evaluate the function.
+    x0 : float or array-like
+        Location of transition.
+    k : float or array-like
+        Inverse of the width of the transition.
+    ylo : float or array-like
+        The value as x goes to -infty.
+    yhi : float or array-like
+        The value as x goes to +infty.
+
+    Returns
+    -------
+    sigmoid : scalar or array-like, same shape as input
+    """
+    return ylo + (yhi - ylo) / (1 + jax_np.exp(-k * (x - x0)))


### PR DESCRIPTION
This PR brings in functions responsible for galaxy quenching. In these models, the star formation history of galaxies follow the main sequence unless/until a quenching event occurs, at which point a sigmoid function shuts down star formation. 

![sigmoid_quenching_function](https://user-images.githubusercontent.com/6951595/75700115-29c71d00-5c77-11ea-862e-4be5c1496c4d.png)

The above figure shows how this works for logM0=12 halos. The time tau_q is just the center of a sigmoid function that smoothly drops SFR to zero over the course of ~1Gyr. 

## Comments on model formulation

The code in this PR decomposes this behavior into two independently modeled pieces. First, for every subhalo core at z=0, we have a parameterized map for the probability that its galaxy ever quenches in its history. Separately, we model the distribution of quenching times tau_q for those galaxies that quench. 

In UniverseMachine, for quenched centrals, the quenching times for group- and cluster-mass halos are tightly clustered at early times around z=2-4, while quenching times for Milky Way mass centrals have a broader distribution centered at later times t_q=10-12Gyr.  I think this general trend is the same in TNG, but @jchavesmontero would know best about this. 

Median quenching times tau_q are modeled with a sigmoid-type dependence on logMhalo. Likewise, the amount of scatter in log10(t_q) is modeled as a sigmoid function of logMhalo. 

## General trends and trends of quenching probability model

![cen_sat_quenching_prob](https://user-images.githubusercontent.com/6951595/75703568-53834280-5c7d-11ea-94f7-6689d2070058.png)

The above figure shows the behavior of the model that maps quenching probabilities to centrals and satellites. For centrals, the quenching probability depends only upon Mpeak. For satellites, the model depends on Mpeak, Mhost, and infall time. For satellites with very small Mhost, and for satellites with very recent infall times, the quenching time of the satellite is just the same as if it were a central. At large Mhost, there is the potential to boost the quenching probability of satellites; the magnitude of this potential boost increases with Mhost. This potential boost is only realized if the satellite infall time exceeds some critical value. Each of these features is implemented by chaining together sigmoid functions such that the quenching probability is analytically differentiable and formally bounded by the interval [0, 1]. 

## General trends and trends of quenching time model

Once a quenching probability has been mapped onto every z=0 core, we need to know the redshift at which that galaxy quenched. That is, we need to map tau_q onto every quenched core. This is necessary to model because we will need to match observational constraints on the quenched fraction as a function of both stellar mass and redshift.

![quenching_time_centrals_twopanel](https://user-images.githubusercontent.com/6951595/75704529-26d02a80-5c7f-11ea-9b6c-4f86ab3c155d.png)

The above figure shows how the tau_q distribution of central galaxies changes when parameters of both of these sigmoids are varied. Larger values of tau_q correspond to galaxies that quench at later times. Solid black shows the median value of tau_q as a function of present-day halo mass.  At fixed present-day halo mass, there is a distribution of tau_q that spans a finite width. The median relation and this width have a halo mass dependence that we control with parameterized sigmoids. The dashed black lines show the width as a function of halo mass. 

For any particular galaxy with halo assembly time proxy y, we calculate p = Prob(<y | logM0). Halos with p=0.5 follow the median relation. Earlier quenching times below this median relation are mapped onto p < 0.5 halos that are earlier-forming; later quenching times are mapped onto p > 0.5 halos that are later-forming. 

Left and right panels show models with a different correlation coefficient between halo assembly and the value of tau_q at fixed mass. The points are color-coded according to the assembly time of the halo, t_h, so that galaxies in early-forming halos quench earlier. In the model in the left panel, there is a 100% correlation coefficient between t_h and tau_q at fixed Mhalo, while in the right panel there is a 25% correlation coefficient.
