### PR TITLE
Added new functions to sigmoid_mah module

### DIFF
--- a/diffmah/sigmoid_mah.py
+++ b/diffmah/sigmoid_mah.py
@@ -1,6 +1,7 @@
 """
 """
 import numpy as np
+from scipy.optimize import minimize
 from collections import OrderedDict
 
 __all__ = ("median_logmpeak_from_logt", "logmpeak_from_logt")
@@ -46,6 +47,80 @@ def median_logmpeak_from_logt(logt, logmpeak_at_t0, logt0=LOGT0, **kwargs):
     return logmpeak
 
 
+def logm0_from_logm_at_logt(
+    logt, logm_at_logt, logtc, logtk, dlogm_height, logt0, tol=0.01
+):
+    """Calculate mass at z=0 from logM(z) and halo MAH params.
+
+    Parameters
+    ----------
+    logt : float
+        Base-10 log of cosmic time where halo attains mass logm_at_logt.
+
+    logm_at_logt : float
+        Base-10 log of halo mass at cosmic time logt
+
+    logtc : float
+        Base-10 log of the critical time in Gyr.
+        Smaller values of logtc produce halos with earlier formation times.
+
+    logtk : float
+        Steepness of transition from fast- to slow-accretion regimes.
+        Larger values of k produce quicker-transitioning halos.
+
+    dlogm_height : float
+        Total gain in logmpeak until logt0
+
+    tol : float, optional
+        Numerical tolerance to use in the minimizer. Default is 0.01.
+
+    Returns
+    -------
+    logm0 : float
+        Base-10 log of halo mass at z=0
+
+    """
+
+    def mse_loss(logm0):
+        pred_logm_at_logt = logmpeak_from_logt(
+            logt, logtc, logtk, dlogm_height, logm0, logt0
+        )
+        diff = pred_logm_at_logt - logm_at_logt
+        return diff * diff
+
+    logm0_guess = (logm_at_logt,)
+    res = minimize(mse_loss, logm0_guess, tol=tol)
+    return res.x[0]
+
+
+def logtc_from_logm_at_logt(
+    logt, logm_at_logt, logm0_table=np.arange(8, 17, 0.05), **mah_params,
+):
+    """Calculate logtc parameter for a halo of mass logm_at_logt at logt.
+
+    Parameters
+    ----------
+    logt : float
+        Base-10 log of cosmic time where halo attains mass logm_at_logt.
+
+    logm_at_logt : float or ndarray
+        Base-10 log of halo mass at cosmic time logt
+
+    **mah_params : float, optional
+        Any parameters in the MAH model dictionary DEFAULT_MAH_PARAMS.
+
+    Returns
+    -------
+    logtc : float or ndarray
+        Parameter of the sigmoid-based model for halo MAH
+
+    """
+    logtc_table = _median_mah_sigmoid_params(logm0_table, **mah_params)[0]
+    logm_at_logt_table = median_logmpeak_from_logt(logt, logm0_table)
+    logtc = np.interp(logm_at_logt, logm_at_logt_table, logtc_table)
+    return logtc
+
+
 def logmpeak_from_logt(logt, logtc, logtk, dlogm_height, logmpeak_at_logt0, logt0):
     """Parametric model for halo mass growth vs cosmic time.
 
@@ -88,23 +163,57 @@ def _sigmoid(x, x0, k, ymin, ymax):
     return ymin + height_diff / (1 + np.exp(-k * (x - x0)))
 
 
-def _median_mah_sigmoid_params(logmpeak, **params):
-    logtc_logm0 = params.get("logtc_logm0", DEFAULT_MAH_PARAMS["logtc_logm0"])
-    logtc_k = params.get("logtc_k", DEFAULT_MAH_PARAMS["logtc_k"])
-    logtc_ymin = params.get("logtc_ymin", DEFAULT_MAH_PARAMS["logtc_ymin"])
-    logtc_ymax = params.get("logtc_ymax", DEFAULT_MAH_PARAMS["logtc_ymax"])
+def _median_mah_sigmoid_params(logm0, **mah_params):
+    """MAH parameters for a halo with present-day mass logm0.
+    """
+    logtc_logm0 = mah_params.get("logtc_logm0", DEFAULT_MAH_PARAMS["logtc_logm0"])
+    logtc_k = mah_params.get("logtc_k", DEFAULT_MAH_PARAMS["logtc_k"])
+    logtc_ymin = mah_params.get("logtc_ymin", DEFAULT_MAH_PARAMS["logtc_ymin"])
+    logtc_ymax = mah_params.get("logtc_ymax", DEFAULT_MAH_PARAMS["logtc_ymax"])
     logtc = _logtc_param_model(
-        logmpeak,
+        logm0,
         logtc_logm0=logtc_logm0,
         logtc_k=logtc_k,
         logtc_ymin=logtc_ymin,
         logtc_ymax=logtc_ymax,
     )
 
-    logtk = np.zeros_like(logmpeak) + DEFAULT_MAH_PARAMS["logtk"]
-    dlogm_height = np.zeros_like(logmpeak) + DEFAULT_MAH_PARAMS["dlogm_height"]
+    _logtk = mah_params.get("logtk", DEFAULT_MAH_PARAMS["logtk"])
+    logtk = np.zeros_like(logm0) + _logtk
+
+    _dlogm_height = mah_params.get("dlogm_height", DEFAULT_MAH_PARAMS["dlogm_height"])
+    dlogm_height = np.zeros_like(logm0) + _dlogm_height
 
     return logtc, logtk, dlogm_height
+
+
+def _mah_sigmoid_params_logm_at_logt(
+    logt, logm_at_logt, logt0=LOGT0, logtc=None, **mah_params
+):
+    """
+    """
+    logt, logm_at_logt = _get_1d_arrays(logt, logm_at_logt)
+    n = logm_at_logt.size
+
+    logtc = np.zeros(n)
+    if logtc is None:
+        for i in range(n):
+            logtc[i] = logtc_from_logm_at_logt(logt[i], logm_at_logt[i], **mah_params)
+    else:
+        logtc = np.zeros(n) + logtc
+
+    logtk = np.zeros(n) + mah_params.get("logtk", DEFAULT_MAH_PARAMS["logtk"])
+    dlogm_height = np.zeros(n) + mah_params.get(
+        "dlogm_height", DEFAULT_MAH_PARAMS["dlogm_height"]
+    )
+
+    logm0 = np.zeros(n)
+    for i in range(n):
+        logm0[i] = logm0_from_logm_at_logt(
+            logt[i], logm_at_logt[i], logtc[i], logtk[i], dlogm_height[i], logt0
+        )
+
+    return logtc, logtk, dlogm_height, logm0
 
 
 def _logtc_param_model(

--- a/diffmah/tests/test_sigmoid_mah.py
+++ b/diffmah/tests/test_sigmoid_mah.py
@@ -2,6 +2,27 @@
 """
 import numpy as np
 from ..sigmoid_mah import median_logmpeak_from_logt, logmpeak_from_logt
+from ..sigmoid_mah import logm0_from_logm_at_logt
+from ..sigmoid_mah import _median_mah_sigmoid_params, logtc_from_logm_at_logt
+from ..sigmoid_mah import _mah_sigmoid_params_logm_at_logt
+
+
+def test1_mah_sigmoid_params_logm_at_logt():
+    logt = 0.8
+    logm_at_logt = 12
+    mah_params = {}
+    logtc, logtk, dlogm_height, logm0 = _mah_sigmoid_params_logm_at_logt(
+        logt, logm_at_logt, logtc=None, **mah_params
+    )
+
+
+def test2_mah_sigmoid_params_logm_at_logt():
+    logt = 0.8
+    logm_at_logt = np.linspace(10, 15, 20)
+    mah_params = {}
+    logtc, logtk, dlogm_height, logm0 = _mah_sigmoid_params_logm_at_logt(
+        logt, logm_at_logt, logtc=None, **mah_params
+    )
 
 
 def test_median_logmpeak_from_logt_is_monotonic_at_z0():
@@ -13,6 +34,18 @@ def test_median_logmpeak_from_logt_is_monotonic_at_z0():
     assert np.all(np.diff(logmah5) > 0)
     assert np.all(np.diff(logmah10) > 0)
     assert np.all(np.diff(logmah15) > 0)
+
+
+def test_median_mah_sigmoid_params_responds_to_input_params():
+    logm0arr = np.linspace(10, 15, 50)
+    logtc1, logtk1, dlogm_height1 = _median_mah_sigmoid_params(logm0arr)
+    logtc2, logtk2, dlogm_height2 = _median_mah_sigmoid_params(logm0arr, logtc_logm0=10)
+    assert not np.allclose(logtc1, logtc2)
+    assert np.allclose(logtk1, logtk2)
+
+    logtc3, logtk3, dlogm_height3 = _median_mah_sigmoid_params(logm0arr, dlogm_height=4)
+    assert not np.allclose(dlogm_height1, dlogm_height3)
+    assert np.allclose(logtc1, logtc3)
 
 
 def test_median_logmpeak_from_logt_behaves_properly_with_logt0():
@@ -28,3 +61,44 @@ def test_logmpeak_from_logt_is_monotonic():
     logmpeak_at_logt0, logt0 = 15, 1.14
     logmah = logmpeak_from_logt(logt, logtc, k, dlogm_height, logmpeak_at_logt0, logt0)
     assert np.all(np.diff(logmah) > 0)
+
+
+def test_logm0_from_logm_at_logt():
+    """
+    """
+    logt0 = 1.14
+    logtc, logtk, dlogm_height = 0, 3, 5
+
+    logtobs_arr = np.linspace(0, logt0, 20)
+    logm0_arr = np.linspace(9, 16, 50)
+    for logtobs in logtobs_arr:
+        for logm0 in logm0_arr:
+            logm_at_logt = logmpeak_from_logt(
+                logtobs, logtc, logtk, dlogm_height, logm0, logt0
+            )
+            pred_logm0 = logm0_from_logm_at_logt(
+                logtobs, logm_at_logt, logtc, logtk, dlogm_height, logt0
+            )
+            assert np.allclose(pred_logm0, logm0, rtol=0.02)
+
+
+def test_logtc_from_logm_at_logt_correctly_inverts():
+    logm0arr = np.linspace(10, 15, 50)
+    logtc_correct = _median_mah_sigmoid_params(logm0arr)[0]
+
+    logtobs = 0.75
+    logm_at_logt = median_logmpeak_from_logt(logtobs, logm0arr)
+    logtc_inferred = logtc_from_logm_at_logt(logtobs, logm_at_logt)
+    assert np.allclose(logtc_inferred, logtc_correct, rtol=0.02)
+
+
+def test_logtc_from_logm_at_logt_changes_with_params():
+    logm0arr = np.linspace(10, 15, 50)
+
+    for logtobs in (0, 0.25, 0.5, 0.75, 1):
+        logm_at_logt = median_logmpeak_from_logt(logtobs, logm0arr)
+        logtc = logtc_from_logm_at_logt(logtobs, logm_at_logt)
+        logtc2 = logtc_from_logm_at_logt(logtobs, logm_at_logt, logtc_logm0=9)
+        logtc3 = logtc_from_logm_at_logt(logtobs, logm_at_logt, dlogm_height=3)
+        assert not np.allclose(logtc, logtc2)
+        assert np.allclose(logtc, logtc3)


### PR DESCRIPTION
The following functions are useful for calculating halo evolution when the halo mass is known at some z>0 redshift:

1. **_mah_sigmoid_params_logm_at_logt**
    calculates sigmoid MAH parameters when the mass is known at z>0
2. **logtc_from_logm_at_logt**
    calculates logtc when the mass is known at z>0
3. **logm0_from_logm_at_logt**
    calculates logm0 when the mass is known at z>0

The **_median_mah_sigmoid_params** function now accepts input logtk and dlogm_height