### PR TITLE
Fixed bug in _mah_sigmoid_params_logm_at_logt function. 

### DIFF
--- a/diffmah/sigmoid_mah.py
+++ b/diffmah/sigmoid_mah.py
@@ -195,8 +195,8 @@ def _mah_sigmoid_params_logm_at_logt(
     logt, logm_at_logt = _get_1d_arrays(logt, logm_at_logt)
     n = logm_at_logt.size
 
-    logtc = np.zeros(n)
     if logtc is None:
+        logtc = np.zeros(n)
         for i in range(n):
             logtc[i] = logtc_from_logm_at_logt(logt[i], logm_at_logt[i], **mah_params)
     else:

--- a/diffmah/tests/test_sigmoid_mah.py
+++ b/diffmah/tests/test_sigmoid_mah.py
@@ -102,3 +102,11 @@ def test_logtc_from_logm_at_logt_changes_with_params():
         logtc3 = logtc_from_logm_at_logt(logtobs, logm_at_logt, dlogm_height=3)
         assert not np.allclose(logtc, logtc2)
         assert np.allclose(logtc, logtc3)
+
+
+def test_mah_sigmoid_params_logm_at_logt():
+    logt, logm_at_logt = 0.75, 12
+    logtc, logtk, dlogm_height, logm0 = _mah_sigmoid_params_logm_at_logt(
+        logt, logm_at_logt, logtc=-0.25
+    )
+    assert np.allclose(logtc, -0.25)


### PR DESCRIPTION
The _mah_sigmoid_params_logm_at_logt function was improperly handling the logtc argument. This is fixed and a regression test has been added.