### PR TITLE
Instate unit-testing with circleci 

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -57,9 +57,6 @@ jobs:
               "halotools>=0.7" \
               "astropy>=4"
 
-            # get thechopper
-            pip install --no-deps git+https://github.com/ArgonneCPAC/thechopper.git#egg=thechopper
-
             pip install --no-deps -e .
 
       - save_cache:


### PR DESCRIPTION
Current set up does not successfully trigger circleci builds and runs of the test suite