### PR TITLE
Fix bug in circleci config

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -17,7 +17,7 @@ jobs:
           name: install dependencies
           command: |
             if [ ! -d miniconda ]; then
-              curl -s https://repo.continuum.io/miniconda/Miniconda3-latest-Linux-x86_64.sh -o miniconda.sh
+              curl -s https://repo.anaconda.com/miniconda/Miniconda3-latest-Linux-x86_64.sh -o miniconda.sh
               bash miniconda.sh -b -p miniconda
 
               export PATH=`pwd`/miniconda/bin:$PATH


### PR DESCRIPTION
I've been getting `conda: command not found` errors in my test runs lately. Thanks to @beckermr  for pointing out that circleci changed their server and curl has not been following links. 