### PR TITLE
Added new function median_halo_mass_assembly_history

### DIFF
--- a/diffmah/tests/test_halo_mah.py
+++ b/diffmah/tests/test_halo_mah.py
@@ -2,6 +2,7 @@
 """
 import numpy as np
 from ..halo_mah import halo_mass_assembly_history
+from ..halo_mah import median_halo_mass_assembly_history
 
 
 def test_halo_mah_evaluates_reasonably_with_default_args():
@@ -12,5 +13,19 @@ def test_halo_mah_evaluates_reasonably_with_default_args():
         for t0 in (13.5, 14):
             cosmic_time = np.linspace(0.1, t0, npts)
             logmah, log_dmhdt = halo_mass_assembly_history(logm0, cosmic_time, t0=t0)
+            assert logmah.size == npts == log_dmhdt.size
+            assert np.allclose(logmah[-1], logm0, atol=0.01)
+
+
+def test_median_halo_mah_evaluates_reasonably_with_default_args():
+    """
+    """
+    npts = 50
+    for logm0 in (11, 12, 13, 14, 15):
+        for t0 in (13.5, 14):
+            cosmic_time = np.linspace(0.1, t0, npts)
+            logmah, log_dmhdt = median_halo_mass_assembly_history(
+                logm0, cosmic_time, t0=t0
+            )
             assert logmah.size == npts == log_dmhdt.size
             assert np.allclose(logmah[-1], logm0, atol=0.01)


### PR DESCRIPTION
The PR brings in a new `median_halo_mass_assembly_history` function. This plot shows the comparison of this function to Consistent Trees run on the Bolshoi-Planck simulation (the UniverseMachine catalogs):

![rolling_powerlaw_mah](https://user-images.githubusercontent.com/6951595/80763765-e2d59680-8b04-11ea-9636-c1426a4a6c9b.png)

The function alpha(t) is a sigmoid function, so that the rolling power law index varies as a function of time, with early- and late-time asymptotic values. The normalization is defined such that the final integrated mass exactly equals the input present-day mass, logM0, by construction. 

By default, the halo is assumed to attain logM0 at z=0; the code permits the halo history to be interpreted to reach logM0 at some other input time logt0, anticipating later fits to subhalo histories.

The sigmoid function alpha(t) has 4 parameters: two asymptotic values, a midpoint, and a transition speed. So in the plot, the shape of each individual dashed curve is characterized by 5 parameters in total. When using this model to fit an individual halo's Mpeak history, the value of logM0 should be set to the value of the halo, and the 4 sigmoid parameters should be varied. (This may be a little slow - if this model works out, a later PR should bring in an MLP approximation to the kernel of this function). 

To capture the behavior of median halo histories, the value of the sigmoid parameters changes with logM0. This dependence is encoded in the model parameter dictionary MEDIAN_MAH_PARAMS, which determines the default behavior of the `median_halo_mass_assembly_history` function. Each of the 4 sigmoid parameters gets 2 parameters to capture its mass-dependence. So then this model describes median halo histories logMh(logM0, t) with 8 parameters in total.