### PR TITLE
Changed API of jax_fitter to return the history of loss and params

### DIFF
--- a/diffmah/tests/test_utils.py
+++ b/diffmah/tests/test_utils.py
@@ -32,9 +32,9 @@ def test_jax_adam_wrapper_actually_minimizes_the_loss():
     data = (x,)
     loss_init = mse_loss(params_init, data)
     n_step = 100
-    params_bestfit, loss = jax_adam_wrapper(
+    params_bestfit, loss_arr, params_arr = jax_adam_wrapper(
         mse_loss, params_init, data, n_step, step_size=0.01
     )
-    assert loss < loss_init
+    assert loss_arr[-1] < loss_init
     params_correct = [3, 1]
     assert np.allclose(params_bestfit, params_correct, atol=0.01)


### PR DESCRIPTION
The wrapper around the Adam algorithm in JAX now return the value of the loss and the parameters at each step taken down the gradient. I think @jchavesmontero was using a custom version of this function that was similar to this implementation, so tagging him about the API change.