### PR TITLE
Fixed bug in wrapper function individual_halo_assembly_history

### DIFF
--- a/diffmah/halo_assembly.py
+++ b/diffmah/halo_assembly.py
@@ -272,9 +272,9 @@ def _process_halo_mah_args(logmp, cosmic_time, tmp):
 
     logt = np.log10(cosmic_time)
     dtarr = _get_dt_array(cosmic_time)
-    present_time_indx = np.argmin(np.abs(cosmic_time - TODAY))
+    indx_tmp = np.argmin(np.abs(cosmic_time - tmp))
 
-    return logmp, logt, dtarr, present_time_indx
+    return logmp, logt, dtarr, indx_tmp
 
 
 def _get_dt_array(t):

--- a/diffmah/tests/test_halo_assembly.py
+++ b/diffmah/tests/test_halo_assembly.py
@@ -27,6 +27,15 @@ def test_halo_mah_evaluates_reasonably_with_default_args():
             assert np.allclose(logmah[-1], logmp, atol=0.01)
 
 
+def test_halo_mah_responds_correctly_to_tmp():
+    npts = 250
+    logmp = 12
+    t = np.linspace(0.1, 14, npts)
+    logmah0, log_dmhdt0 = individual_halo_assembly_history(t, logmp)
+    logmah1, log_dmhdt1 = individual_halo_assembly_history(t, logmp, tmp=10)
+    assert not np.allclose(logmah0, logmah1)
+
+
 def test_avg_halo_mah_evaluates_reasonably_with_default_args():
     """
     """


### PR DESCRIPTION
Inside _process_halo_mah_args, was accidentally using TODAY rather than input tmp to define indx_tmp. Now fixed.