### PR TITLE
Fixed testing error of jax Adam wrapper

### DIFF
--- a/diffmah/tests/test_utils.py
+++ b/diffmah/tests/test_utils.py
@@ -36,7 +36,7 @@ def test_jax_adam_wrapper_actually_minimizes_the_loss():
         mse_loss, params_init, data, n_step, step_size=0.01
     )
     assert loss_arr[-1] < loss_init
-    assert loss_bestfit <= loss_arr[-1]
+    assert np.allclose(loss_bestfit, loss_arr[-1], atol=0.001)
 
     params_correct = [3, 1]
     assert np.allclose(params_bestfit, params_correct, atol=0.01)


### PR DESCRIPTION
The returned loss value is now expected to be equal to or slightly less than the final value of the returned loss_arr