### PR TITLE
Added main_sequence_tng.py model of the main sequence

### DIFF
--- a/diffmah/main_sequence_tng.py
+++ b/diffmah/main_sequence_tng.py
@@ -1,0 +1,66 @@
+"""Model for the star-forming main sequence of TNG central galaxies across time."""
+from jax import numpy as jnp
+from jax import jit as jjit
+
+
+@jjit
+def main_sequence_log_ssfr_tng(logsm, time):
+    """Mean sSFR across mass and time.
+
+    Parameters
+    ----------
+    logsm : float or ndarray
+
+    time : float or ndarray
+
+    Returns
+    -------
+    log_ssfr : ndarray
+        Stores base-10 log of SFR/Mstar of star-forming TNG centrals
+
+    """
+    x0 = _x0_vs_time(time)
+    k = _k_vs_time(time)
+    ymin = _ymin_vs_time(time)
+    ymax = _ymax_vs_time(time)
+    log_ssfr = _sigmoid(logsm, x0, k, ymin, ymax)
+    return log_ssfr
+
+
+@jjit
+def main_sequence_scatter_tng(time):
+    """Scatter in sSFR across time.
+
+    Parameters
+    ----------
+    time : float or ndarray
+
+    Returns
+    -------
+    scatter : ndarray
+        Scatter of sSFR in dex of star-forming TNG centrals
+
+    """
+    return _sigmoid(time, x0=1.5, k=0.8, ymin=0, ymax=0.3)
+
+
+@jjit
+def _sigmoid(x, x0=0, k=1, ymin=-1, ymax=1):
+    height_diff = ymax - ymin
+    return ymin + height_diff / (1 + jnp.exp(-k * (x - x0)))
+
+
+def _x0_vs_time(time):
+    return _sigmoid(time, x0=8.5, k=0.5, ymin=11, ymax=11.325)
+
+
+def _k_vs_time(time):
+    return _sigmoid(time, x0=8.5, k=0.25, ymin=1.5, ymax=3.4)
+
+
+def _ymin_vs_time(time):
+    return _sigmoid(time, x0=8.5, k=0.1, ymin=-11.1, ymax=-7.1)
+
+
+def _ymax_vs_time(time):
+    return _sigmoid(time, x0=12.0, k=0.1, ymin=-12.5, ymax=-7)


### PR DESCRIPTION
Approximate model for the star-forming sequence of TNG centrals as a function of stellar mass and time. This should be useful target data to fit diffmah parameters (along with the stellar-to-halo-mass relation and the quenched fraction). 

In each figure, colored lines are direct measurements in the simulation, and the black curves are a smooth log-normal model approximating the trend. 

![main_sequence_tng_z0](https://user-images.githubusercontent.com/6951595/96195415-5718c080-0f12-11eb-9da7-629900110d8c.png)
![main_sequence_tng_z0p5](https://user-images.githubusercontent.com/6951595/96195467-77e11600-0f12-11eb-93c6-19e4a125add5.png)
![main_sequence_tng_z1](https://user-images.githubusercontent.com/6951595/96195476-7b749d00-0f12-11eb-8949-37421c966f24.png)
![main_sequence_tng_z2](https://user-images.githubusercontent.com/6951595/96195491-829bab00-0f12-11eb-8070-f9bd617cd486.png)
![main_sequence_tng_z4](https://user-images.githubusercontent.com/6951595/96195498-86c7c880-0f12-11eb-9b89-c1db2611624a.png)

