### PR TITLE
Added calc_individual_halo_history convenience function

### DIFF
--- a/diffmah/individual_halo_assembly.py
+++ b/diffmah/individual_halo_assembly.py
@@ -4,7 +4,7 @@ from jax import numpy as jnp
 from jax import jit as jjit
 from jax import vmap as jvmap
 from jax import grad
-
+import numpy as np
 
 _MAH_PARS = OrderedDict(mah_x0=-0.15, mah_k=3.5, mah_early=3.0, mah_dy=0.75)
 _MAH_BOUNDS = OrderedDict(
@@ -13,6 +13,42 @@ _MAH_BOUNDS = OrderedDict(
     mah_early=(1.0, 20.0),
 )
 _PBOUND_X0, _PBOUND_K = 0.0, 0.1
+
+
+def calc_individual_halo_history(cosmic_time, logmp, early, late, tmpeak):
+    """Calculate the history of an individual halo as a function of cosmic time.
+
+    Parameters
+    ----------
+    cosmic_time : ndarray of shape (n_times, )
+        Age of the Universe in Gyr
+
+    logmp : float
+        Base-10 log of peak halo mass in units of Msun
+
+    early : float
+        Early-time power-law index of the scaling between halo mass and cosmic time.
+
+    late : float
+        Late-time power-law index of the scaling between halo mass and cosmic time.
+
+    tmpeak : float
+        Time the halo first reaches its peak mass in Gyr
+
+    Returns
+    -------
+    dmhdt : ndarray of shape (n_times, )
+        Mass accretion rate of the halo in units of Msun/yr
+
+    log_mah : ndarray of shape (n_times, )
+        Base-10 log of the cumulative mass of the halo in units of Msun
+
+    """
+    logt = np.log10(cosmic_time)
+    logtmp = np.log10(tmpeak)
+    x0 = _get_x0_from_early_index(early)
+    k = _MAH_PARS["mah_k"]
+    return _calc_halo_history(logt, logtmp, logmp, x0, k, early, late)
 
 
 @jjit


### PR DESCRIPTION
This PR brings in the `calc_individual_halo_history` convenience function for calculating the assembly history of an individual halo.

@acossairt have a look at the docstring and see if it makes sense. You should be able to use this function to make plots like the ones shown in the first two slides of [this presentation.](https://docs.google.com/presentation/d/1Cs2YAj5lrzEDinVH4bUK2-rD5Uhlhqudr3Zxe6Lu6Y8/edit?usp=sharing). The transition between the early-time and late-time power-law indices is just governed by a smoothly rolling sigmoid function. Since the `calc_individual_halo_history` function provides the full halo history at any time t, then you can use this function to derive a halo assembly time (and consequently, a notion of "early-forming" or "late-forming") based on whatever definition you choose. 