### PR TITLE
New model for the assembly history of halo populations

### DIFF
--- a/diffmah/halo_population_assembly.py
+++ b/diffmah/halo_population_assembly.py
@@ -1,0 +1,161 @@
+"""Calculate differentiable average halo histories."""
+from jax import numpy as jnp
+from jax import jit as jjit
+from jax import vmap
+from jax.scipy.stats import multivariate_normal as jnorm
+from .individual_halo_assembly import _calc_halo_history, _MAH_PARS
+from .mah_pop_param_model import frac_late_forming
+from .mah_pop_param_model import _get_cov_early, _get_cov_late
+from .mah_pop_param_model import _get_mean_mah_params_early, _get_mean_mah_params_late
+
+from .mah_pop_param_model import FRAC_LATE_FORMING_PARAMS
+from .mah_pop_param_model import MEAN_PARAMS_EARLY, MEAN_PARAMS_LATE
+from .mah_pop_param_model import COV_PARAMS_EARLY, COV_PARAMS_LATE
+
+TODAY = 13.8
+LGT0 = jnp.log10(TODAY)
+
+
+_g0 = vmap(_calc_halo_history, in_axes=(None, None, 0, *[None] * 4))
+_g1 = vmap(_g0, in_axes=(*[None] * 5, 0, None))
+_g2 = vmap(_g1, in_axes=(*[None] * 5, None, 0))
+_halo_history_integrand = jjit(vmap(_g2, in_axes=(*[None] * 3, 0, *[None] * 3)))
+
+
+def _multivariate_normal_pdf_kernel(lge, lgl, x0, mu, cov):
+    X = jnp.array((lge, lgl, x0)).astype("f4")
+    return jnorm.pdf(X, mu, cov)
+
+
+_g0 = vmap(_multivariate_normal_pdf_kernel, in_axes=(None, None, None, 0, 0))
+_g1 = vmap(_g0, in_axes=(0, None, None, None, None))
+_g2 = vmap(_g1, in_axes=(None, 0, None, None, None))
+_get_pdf_weights_kern = vmap(_g2, in_axes=(None, None, 0, None, None))
+
+
+@jjit
+def _get_mah_weights(lge_arr, lgl_arr, x0_arr, mu_arr, cov_arr):
+    _pdf = _get_pdf_weights_kern(lge_arr, lgl_arr, x0_arr, mu_arr, cov_arr)
+    n_halos = _pdf.shape[-1]
+    _norm = jnp.sum(_pdf, axis=(0, 1, 2))
+    _norm = jnp.where(_norm == 0, 1.0, _norm)
+    pdf = _pdf / _norm.reshape((1, 1, 1, n_halos))
+    return pdf
+
+
+@jjit
+def _get_halo_mahs(
+    logt, logmp_arr, lge_arr, lgl_arr, x0_arr, k=_MAH_PARS["mah_k"], logtmp=LGT0
+):
+    dmhdt, log_mah = _halo_history_integrand(
+        logt, logtmp, logmp_arr, x0_arr, k, 10 ** lge_arr, 10 ** lgl_arr
+    )
+    return dmhdt, log_mah
+
+
+@jjit
+def _get_average_halo_histories(
+    logt,
+    logmp_arr,
+    lge_arr,
+    lgl_arr,
+    x0_arr,
+    frac_late_forming_lo=FRAC_LATE_FORMING_PARAMS["frac_late_forming_lo"],
+    frac_late_forming_hi=FRAC_LATE_FORMING_PARAMS["frac_late_forming_hi"],
+    lge_early_lo=MEAN_PARAMS_EARLY["lge_early_lo"],
+    lge_early_hi=MEAN_PARAMS_EARLY["lge_early_hi"],
+    lgl_early_lo=MEAN_PARAMS_EARLY["lgl_early_lo"],
+    lgl_early_hi=MEAN_PARAMS_EARLY["lgl_early_hi"],
+    x0_early=MEAN_PARAMS_EARLY["x0_early"],
+    lge_late_lo=MEAN_PARAMS_LATE["lge_late_lo"],
+    lge_late_hi=MEAN_PARAMS_LATE["lge_late_hi"],
+    lgl_late_lo=MEAN_PARAMS_LATE["lgl_late_lo"],
+    lgl_late_hi=MEAN_PARAMS_LATE["lgl_late_hi"],
+    x0_late=MEAN_PARAMS_LATE["x0_late"],
+    log_cho_lge_lge_early_lo=COV_PARAMS_EARLY["log_cho_lge_lge_early_lo"],
+    log_cho_lge_lge_early_hi=COV_PARAMS_EARLY["log_cho_lge_lge_early_hi"],
+    log_cho_lgl_lgl_early_lo=COV_PARAMS_EARLY["log_cho_lgl_lgl_early_lo"],
+    log_cho_lgl_lgl_early_hi=COV_PARAMS_EARLY["log_cho_lgl_lgl_early_hi"],
+    log_cho_x0_x0_early=COV_PARAMS_EARLY["log_cho_x0_x0_early"],
+    cho_lge_lgl_early=COV_PARAMS_EARLY["cho_lge_lgl_early"],
+    cho_lge_x0_early=COV_PARAMS_EARLY["cho_lge_x0_early"],
+    cho_lgl_x0_early=COV_PARAMS_EARLY["cho_lgl_x0_early"],
+    log_cho_lge_lge_late_lo=COV_PARAMS_LATE["log_cho_lge_lge_late_lo"],
+    log_cho_lge_lge_late_hi=COV_PARAMS_LATE["log_cho_lge_lge_late_hi"],
+    log_cho_lgl_lgl_late_lo=COV_PARAMS_LATE["log_cho_lgl_lgl_late_lo"],
+    log_cho_lgl_lgl_late_hi=COV_PARAMS_LATE["log_cho_lgl_lgl_late_hi"],
+    log_cho_x0_x0_late=COV_PARAMS_LATE["log_cho_x0_x0_late"],
+    cho_lge_lgl_late=COV_PARAMS_LATE["cho_lge_lgl_late"],
+    cho_lge_x0_late=COV_PARAMS_LATE["cho_lge_x0_late"],
+    cho_lgl_x0_late=COV_PARAMS_LATE["cho_lgl_x0_late"],
+    k=_MAH_PARS["mah_k"],
+    logtmp=LGT0,
+):
+    dmhdts, log_mahs = _halo_history_integrand(
+        logt, logtmp, logmp_arr, x0_arr, k, 10 ** lge_arr, 10 ** lgl_arr
+    )
+    mahs = 10 ** log_mahs
+
+    lge_early, lgl_early, x0_early = _get_mean_mah_params_early(
+        logmp_arr, lge_early_lo, lge_early_hi, lgl_early_lo, lgl_early_hi, x0_early
+    )
+    means_early = jnp.array((lge_early, lgl_early, x0_early)).T
+
+    lge_late, lgl_late, x0_late = _get_mean_mah_params_late(
+        logmp_arr, lge_late_lo, lge_late_hi, lgl_late_lo, lgl_late_hi, x0_late
+    )
+    means_late = jnp.array((lge_late, lgl_late, x0_late)).T
+
+    covs_late = _get_cov_late(
+        logmp_arr,
+        log_cho_lge_lge_late_lo,
+        log_cho_lge_lge_late_hi,
+        log_cho_lgl_lgl_late_lo,
+        log_cho_lgl_lgl_late_hi,
+        log_cho_x0_x0_late,
+        cho_lge_lgl_late,
+        cho_lge_x0_late,
+        cho_lgl_x0_late,
+    )
+    covs_early = _get_cov_early(
+        logmp_arr,
+        log_cho_lge_lge_early_lo,
+        log_cho_lge_lge_early_hi,
+        log_cho_lgl_lgl_early_lo,
+        log_cho_lgl_lgl_early_hi,
+        log_cho_x0_x0_early,
+        cho_lge_lgl_early,
+        cho_lge_x0_early,
+        cho_lgl_x0_early,
+    )
+
+    weights_early = _get_mah_weights(lge_arr, lgl_arr, x0_arr, means_early, covs_early)
+    weights_late = _get_mah_weights(lge_arr, lgl_arr, x0_arr, means_late, covs_late)
+
+    frac_late = frac_late_forming(logmp_arr, frac_late_forming_lo, frac_late_forming_hi)
+
+    n_x0, n_late, n_early, n_halos, n_t = log_mahs.shape
+    _wshape = n_x0, n_late, n_early, n_halos, 1
+    w_early = ((1 - frac_late) * weights_early).reshape(_wshape)
+    w_late = (frac_late * weights_late).reshape(_wshape)
+
+    w_dmhdts = dmhdts * w_early + dmhdts * w_late
+    w_mahs = mahs * w_early + mahs * w_late
+    mean_dmhdts = jnp.sum(w_dmhdts, axis=(0, 1, 2))
+    mean_mahs = jnp.sum(w_mahs, axis=(0, 1, 2))
+    mean_log_mahs = jnp.log10(mean_mahs)
+
+    delta_dmhdt_sq = (dmhdts - mean_dmhdts) ** 2
+    delta_log_mah_sq = (log_mahs - mean_log_mahs) ** 2
+
+    variance_dmhdt = jnp.sum(
+        delta_dmhdt_sq * w_early + delta_dmhdt_sq * w_late, axis=(0, 1, 2)
+    )
+    variance_log_mah = jnp.sum(
+        delta_log_mah_sq * w_early + delta_log_mah_sq * w_late, axis=(0, 1, 2)
+    )
+
+    std_dmhdt = jnp.sqrt(variance_dmhdt)
+    std_log_mah = jnp.sqrt(variance_log_mah)
+
+    return mean_dmhdts, mean_log_mahs, std_dmhdt, std_log_mah

--- a/diffmah/mah_pop_param_model.py
+++ b/diffmah/mah_pop_param_model.py
@@ -1,0 +1,475 @@
+"""Models for mass-dependence of mean and cov of params early, late, x0"""
+from collections import OrderedDict
+from jax import numpy as jnp
+from jax import jit as jjit
+from jax import ops as jops
+from jax import vmap
+from jax.scipy.stats import multivariate_normal as jnorm
+
+FRAC_LATE_FORMING_PARAMS = OrderedDict(
+    frac_late_forming_lo=0.45, frac_late_forming_hi=0.58
+)
+
+LGE_EARLY_PARAMS = OrderedDict(lge_early_lo=0.425, lge_early_hi=0.875)
+LGL_EARLY_PARAMS = OrderedDict(lgl_early_lo=-0.6, lgl_early_hi=0.15)
+X0_EARLY_PARAMS = OrderedDict(x0_early=-0.26)
+MEAN_PARAMS_EARLY = OrderedDict()
+MEAN_PARAMS_EARLY.update(LGE_EARLY_PARAMS)
+MEAN_PARAMS_EARLY.update(LGL_EARLY_PARAMS)
+MEAN_PARAMS_EARLY.update(X0_EARLY_PARAMS)
+
+LGE_LATE_PARAMS = OrderedDict(lge_late_lo=-0.1, lge_late_hi=0.7)
+LGL_LATE_PARAMS = OrderedDict(lgl_late_lo=-1.5, lgl_late_hi=0.4)
+X0_LATE_PARAMS = OrderedDict(x0_late=0.55)
+MEAN_PARAMS_LATE = OrderedDict()
+MEAN_PARAMS_LATE.update(LGE_LATE_PARAMS)
+MEAN_PARAMS_LATE.update(LGL_LATE_PARAMS)
+MEAN_PARAMS_LATE.update(X0_LATE_PARAMS)
+
+
+LOG_CHO_LGE_LGE_EARLY_PARAMS = OrderedDict(
+    log_cho_lge_lge_early_lo=-0.4, log_cho_lge_lge_early_hi=-0.8
+)
+LOG_CHO_LGL_LGL_EARLY_PARAMS = OrderedDict(
+    log_cho_lgl_lgl_early_lo=-0.25, log_cho_lgl_lgl_early_hi=-1.05
+)
+LOG_CHO_X0_X0_EARLY_PARAMS = OrderedDict(log_cho_x0_x0_early=-0.85)
+CHO_LGE_LGL_EARLY_PARAMS = OrderedDict(cho_lge_lgl_early=-0.08)
+CHO_LGE_X0_EARLY_PARAMS = OrderedDict(cho_lge_x0_early=-0.1)
+CHO_LGL_X0_EARLY_PARAMS = OrderedDict(cho_lgl_x0_early=-0.08)
+COV_PARAMS_EARLY = OrderedDict()
+COV_PARAMS_EARLY.update(LOG_CHO_LGE_LGE_EARLY_PARAMS)
+COV_PARAMS_EARLY.update(LOG_CHO_LGL_LGL_EARLY_PARAMS)
+COV_PARAMS_EARLY.update(LOG_CHO_X0_X0_EARLY_PARAMS)
+COV_PARAMS_EARLY.update(CHO_LGE_LGL_EARLY_PARAMS)
+COV_PARAMS_EARLY.update(CHO_LGE_X0_EARLY_PARAMS)
+COV_PARAMS_EARLY.update(CHO_LGL_X0_EARLY_PARAMS)
+
+
+LOG_CHO_LGE_LGE_LATE_PARAMS = OrderedDict(
+    log_cho_lge_lge_late_lo=-0.675, log_cho_lge_lge_late_hi=-1.125
+)
+LOG_CHO_LGL_LGL_LATE_PARAMS = OrderedDict(
+    log_cho_lgl_lgl_late_lo=-0.3, log_cho_lgl_lgl_late_hi=-0.45
+)
+LOG_CHO_X0_X0_LATE_PARAMS = OrderedDict(log_cho_x0_x0_late=-0.75)
+CHO_LGE_LGL_LATE_PARAMS = OrderedDict(cho_lge_lgl_late=-0.1)
+CHO_LGE_X0_LATE_PARAMS = OrderedDict(cho_lge_x0_late=-0.08)
+CHO_LGL_X0_LATE_PARAMS = OrderedDict(cho_lgl_x0_late=-0.02)
+COV_PARAMS_LATE = OrderedDict()
+COV_PARAMS_LATE.update(LOG_CHO_LGE_LGE_LATE_PARAMS)
+COV_PARAMS_LATE.update(LOG_CHO_LGL_LGL_LATE_PARAMS)
+COV_PARAMS_LATE.update(LOG_CHO_X0_X0_LATE_PARAMS)
+COV_PARAMS_LATE.update(CHO_LGE_LGL_LATE_PARAMS)
+COV_PARAMS_LATE.update(CHO_LGE_X0_LATE_PARAMS)
+COV_PARAMS_LATE.update(CHO_LGL_X0_LATE_PARAMS)
+
+
+def _get_cov_scalar(
+    log10_lge_lge,
+    log10_lgl_lgl,
+    log10_x0_x0,
+    lge_lgl,
+    lge_x0,
+    lgl_x0,
+):
+    cho = jnp.zeros((3, 3)).astype("f4")
+    cho = jops.index_update(cho, jops.index[0, 0], 10 ** log10_lge_lge)
+    cho = jops.index_update(cho, jops.index[1, 1], 10 ** log10_lgl_lgl)
+    cho = jops.index_update(cho, jops.index[2, 2], 10 ** log10_x0_x0)
+    cho = jops.index_update(cho, jops.index[1, 0], lge_lgl)
+    cho = jops.index_update(cho, jops.index[2, 0], lge_x0)
+    cho = jops.index_update(cho, jops.index[2, 1], lgl_x0)
+    cov = jnp.dot(cho, cho.T)
+    return cov
+
+
+_get_cov_vmap = jjit(vmap(_get_cov_scalar, in_axes=(0, 0, 0, 0, 0, 0)))
+
+
+@jjit
+def _get_cov_early(
+    lgm,
+    log_cho_lge_lge_early_lo=LOG_CHO_LGE_LGE_EARLY_PARAMS["log_cho_lge_lge_early_lo"],
+    log_cho_lge_lge_early_hi=LOG_CHO_LGE_LGE_EARLY_PARAMS["log_cho_lge_lge_early_hi"],
+    log_cho_lgl_lgl_early_lo=LOG_CHO_LGL_LGL_EARLY_PARAMS["log_cho_lgl_lgl_early_lo"],
+    log_cho_lgl_lgl_early_hi=LOG_CHO_LGL_LGL_EARLY_PARAMS["log_cho_lgl_lgl_early_hi"],
+    log_cho_x0_x0_early=LOG_CHO_X0_X0_EARLY_PARAMS["log_cho_x0_x0_early"],
+    cho_lge_lgl_early=CHO_LGE_LGL_EARLY_PARAMS["cho_lge_lgl_early"],
+    cho_lge_x0_early=CHO_LGE_X0_EARLY_PARAMS["cho_lge_x0_early"],
+    cho_lgl_x0_early=CHO_LGL_X0_EARLY_PARAMS["cho_lgl_x0_early"],
+):
+    _res = _get_cov_mah_params_early(
+        lgm,
+        log_cho_lge_lge_early_lo,
+        log_cho_lge_lge_early_hi,
+        log_cho_lgl_lgl_early_lo,
+        log_cho_lgl_lgl_early_hi,
+        log_cho_x0_x0_early,
+        cho_lge_lgl_early,
+        cho_lge_x0_early,
+        cho_lgl_x0_early,
+    )
+    return _get_cov_vmap(*_res)
+
+
+@jjit
+def _get_cov_late(
+    lgm,
+    log_cho_lge_lge_late_lo=LOG_CHO_LGE_LGE_LATE_PARAMS["log_cho_lge_lge_late_lo"],
+    log_cho_lge_lge_late_hi=LOG_CHO_LGE_LGE_LATE_PARAMS["log_cho_lge_lge_late_hi"],
+    log_cho_lgl_lgl_late_lo=LOG_CHO_LGL_LGL_LATE_PARAMS["log_cho_lgl_lgl_late_lo"],
+    log_cho_lgl_lgl_late_hi=LOG_CHO_LGL_LGL_LATE_PARAMS["log_cho_lgl_lgl_late_hi"],
+    log_cho_x0_x0_late=LOG_CHO_X0_X0_LATE_PARAMS["log_cho_x0_x0_late"],
+    cho_lge_lgl_late=CHO_LGE_LGL_LATE_PARAMS["cho_lge_lgl_late"],
+    cho_lge_x0_late=CHO_LGE_X0_LATE_PARAMS["cho_lge_x0_late"],
+    cho_lgl_x0_late=CHO_LGL_X0_LATE_PARAMS["cho_lgl_x0_late"],
+):
+    _res = _get_cov_mah_params_late(
+        lgm,
+        log_cho_lge_lge_late_lo,
+        log_cho_lge_lge_late_hi,
+        log_cho_lgl_lgl_late_lo,
+        log_cho_lgl_lgl_late_hi,
+        log_cho_x0_x0_late,
+        cho_lge_lgl_late,
+        cho_lge_x0_late,
+        cho_lgl_x0_late,
+    )
+    return _get_cov_vmap(*_res)
+
+
+@jjit
+def _get_cov_mah_params_early(
+    lgm,
+    log_cho_lge_lge_early_lo=LOG_CHO_LGE_LGE_EARLY_PARAMS["log_cho_lge_lge_early_lo"],
+    log_cho_lge_lge_early_hi=LOG_CHO_LGE_LGE_EARLY_PARAMS["log_cho_lge_lge_early_hi"],
+    log_cho_lgl_lgl_early_lo=LOG_CHO_LGL_LGL_EARLY_PARAMS["log_cho_lgl_lgl_early_lo"],
+    log_cho_lgl_lgl_early_hi=LOG_CHO_LGL_LGL_EARLY_PARAMS["log_cho_lgl_lgl_early_hi"],
+    log_cho_x0_x0_early=LOG_CHO_X0_X0_EARLY_PARAMS["log_cho_x0_x0_early"],
+    cho_lge_lgl_early=CHO_LGE_LGL_EARLY_PARAMS["cho_lge_lgl_early"],
+    cho_lge_x0_early=CHO_LGE_X0_EARLY_PARAMS["cho_lge_x0_early"],
+    cho_lgl_x0_early=CHO_LGL_X0_EARLY_PARAMS["cho_lgl_x0_early"],
+):
+    log10_lge_lge = _log_cho_lge_lge_early(
+        lgm, log_cho_lge_lge_early_lo, log_cho_lge_lge_early_hi
+    )
+    log10_lgl_lgl = _log_cho_lgl_lgl_early(
+        lgm, log_cho_lgl_lgl_early_lo, log_cho_lgl_lgl_early_hi
+    )
+    log10_x0_x0 = _log_cho_x0_x0_early(lgm, log_cho_x0_x0_early)
+
+    lge_lgl = _cho_lge_lgl_early(lgm, cho_lge_lgl_early)
+    lge_x0 = _cho_lge_x0_early(lgm, cho_lge_x0_early)
+    lgl_x0 = _cho_lgl_x0_early(lgm, cho_lgl_x0_early)
+    return log10_lge_lge, log10_lgl_lgl, log10_x0_x0, lge_lgl, lge_x0, lgl_x0
+
+
+@jjit
+def _get_cov_mah_params_late(
+    lgm,
+    log_cho_lge_lge_late_lo=LOG_CHO_LGE_LGE_LATE_PARAMS["log_cho_lge_lge_late_lo"],
+    log_cho_lge_lge_late_hi=LOG_CHO_LGE_LGE_LATE_PARAMS["log_cho_lge_lge_late_hi"],
+    log_cho_lgl_lgl_late_lo=LOG_CHO_LGL_LGL_LATE_PARAMS["log_cho_lgl_lgl_late_lo"],
+    log_cho_lgl_lgl_late_hi=LOG_CHO_LGL_LGL_LATE_PARAMS["log_cho_lgl_lgl_late_hi"],
+    log_cho_x0_x0_late=LOG_CHO_X0_X0_LATE_PARAMS["log_cho_x0_x0_late"],
+    cho_lge_lgl_late=CHO_LGE_LGL_LATE_PARAMS["cho_lge_lgl_late"],
+    cho_lge_x0_late=CHO_LGE_X0_LATE_PARAMS["cho_lge_x0_late"],
+    cho_lgl_x0_late=CHO_LGL_X0_LATE_PARAMS["cho_lgl_x0_late"],
+):
+    log10_lge_lge = _log_cho_lge_lge_late(
+        lgm, log_cho_lge_lge_late_lo, log_cho_lge_lge_late_hi
+    )
+    log10_lgl_lgl = _log_cho_lgl_lgl_late(
+        lgm, log_cho_lgl_lgl_late_lo, log_cho_lgl_lgl_late_hi
+    )
+    log10_x0_x0 = _log_cho_x0_x0_late(lgm, log_cho_x0_x0_late)
+
+    lge_lgl = _cho_lge_lgl_late(lgm, cho_lge_lgl_late)
+    lge_x0 = _cho_lge_x0_late(lgm, cho_lge_x0_late)
+    lgl_x0 = _cho_lgl_x0_late(lgm, cho_lgl_x0_late)
+    return log10_lge_lge, log10_lgl_lgl, log10_x0_x0, lge_lgl, lge_x0, lgl_x0
+
+
+@jjit
+def _get_mean_mah_params_early(
+    lgm,
+    lge_early_lo=LGE_EARLY_PARAMS["lge_early_lo"],
+    lge_early_hi=LGE_EARLY_PARAMS["lge_early_hi"],
+    lgl_early_lo=LGL_EARLY_PARAMS["lgl_early_lo"],
+    lgl_early_hi=LGL_EARLY_PARAMS["lgl_early_hi"],
+    x0_early=X0_EARLY_PARAMS["x0_early"],
+):
+    lge = _lge_vs_lgm_early(lgm, lge_early_lo, lge_early_hi)
+    lgl = _lgl_vs_lgm_early(lgm, lgl_early_lo, lgl_early_hi)
+    x0 = _x0_vs_lgm_early(lgm, x0_early)
+    return lge, lgl, x0
+
+
+@jjit
+def _get_mean_mah_params_late(
+    lgm,
+    lge_late_lo=LGE_LATE_PARAMS["lge_late_lo"],
+    lge_late_hi=LGE_LATE_PARAMS["lge_late_hi"],
+    lgl_late_lo=LGL_LATE_PARAMS["lgl_late_lo"],
+    lgl_late_hi=LGL_LATE_PARAMS["lgl_late_hi"],
+    x0_late=X0_LATE_PARAMS["x0_late"],
+):
+    lge = _lge_vs_lgm_late(lgm, lge_late_lo, lge_late_hi)
+    lgl = _lgl_vs_lgm_late(lgm, lgl_late_lo, lgl_late_hi)
+    x0 = _x0_vs_lgm_late(lgm, x0_late)
+    return lge, lgl, x0
+
+
+@jjit
+def frac_late_forming(
+    lgm,
+    frac_late_forming_lo=FRAC_LATE_FORMING_PARAMS["frac_late_forming_lo"],
+    frac_late_forming_hi=FRAC_LATE_FORMING_PARAMS["frac_late_forming_hi"],
+):
+    """Fraction of halos with mah_x0 > 0.15"""
+    return _sigmoid(lgm, 13, 0.5, frac_late_forming_lo, frac_late_forming_hi)
+
+
+@jjit
+def _cho_lgl_x0_late(
+    lgm,
+    cho_lgl_x0_late=CHO_LGL_X0_LATE_PARAMS["cho_lgl_x0_late"],
+):
+    return jnp.zeros_like(lgm) + cho_lgl_x0_late
+
+
+@jjit
+def _cho_lgl_x0_early(
+    lgm,
+    cho_lgl_x0_early=CHO_LGL_X0_EARLY_PARAMS["cho_lgl_x0_early"],
+):
+    return jnp.zeros_like(lgm) + cho_lgl_x0_early
+
+
+@jjit
+def _cho_lge_x0_late(
+    lgm,
+    cho_lge_x0_late=CHO_LGE_X0_LATE_PARAMS["cho_lge_x0_late"],
+):
+    return jnp.zeros_like(lgm) + cho_lge_x0_late
+
+
+@jjit
+def _cho_lge_x0_early(
+    lgm,
+    cho_lge_x0_early=CHO_LGE_X0_EARLY_PARAMS["cho_lge_x0_early"],
+):
+    return jnp.zeros_like(lgm) + cho_lge_x0_early
+
+
+@jjit
+def _cho_lge_lgl_late(
+    lgm,
+    cho_lge_lgl_late=CHO_LGE_LGL_LATE_PARAMS["cho_lge_lgl_late"],
+):
+    return jnp.zeros_like(lgm) + cho_lge_lgl_late
+
+
+@jjit
+def _cho_lge_lgl_early(
+    lgm,
+    cho_lge_lgl_early=CHO_LGE_LGL_EARLY_PARAMS["cho_lge_lgl_early"],
+):
+    return jnp.zeros_like(lgm) + cho_lge_lgl_early
+
+
+@jjit
+def _log_cho_x0_x0_early(
+    lgm,
+    log_cho_x0_x0_early=LOG_CHO_X0_X0_EARLY_PARAMS["log_cho_x0_x0_early"],
+):
+    return jnp.zeros_like(lgm) + log_cho_x0_x0_early
+
+
+@jjit
+def _log_cho_x0_x0_late(
+    lgm,
+    log_cho_x0_x0_late=LOG_CHO_X0_X0_LATE_PARAMS["log_cho_x0_x0_late"],
+):
+    return jnp.zeros_like(lgm) + log_cho_x0_x0_late
+
+
+@jjit
+def _log_cho_lgl_lgl_early(
+    lgm,
+    log_cho_lgl_lgl_early_lo=LOG_CHO_LGL_LGL_EARLY_PARAMS["log_cho_lgl_lgl_early_lo"],
+    log_cho_lgl_lgl_early_hi=LOG_CHO_LGL_LGL_EARLY_PARAMS["log_cho_lgl_lgl_early_hi"],
+):
+    return _sigmoid(lgm, 13, 0.5, log_cho_lgl_lgl_early_lo, log_cho_lgl_lgl_early_hi)
+
+
+@jjit
+def _log_cho_lgl_lgl_late(
+    lgm,
+    log_cho_lgl_lgl_late_lo=LOG_CHO_LGL_LGL_LATE_PARAMS["log_cho_lgl_lgl_late_lo"],
+    log_cho_lgl_lgl_late_hi=LOG_CHO_LGL_LGL_LATE_PARAMS["log_cho_lgl_lgl_late_hi"],
+):
+    return _sigmoid(lgm, 13.5, 2.0, log_cho_lgl_lgl_late_lo, log_cho_lgl_lgl_late_hi)
+
+
+@jjit
+def _log_cho_lge_lge_late(
+    lgm,
+    log_cho_lge_lge_late_lo=LOG_CHO_LGE_LGE_LATE_PARAMS["log_cho_lge_lge_late_lo"],
+    log_cho_lge_lge_late_hi=LOG_CHO_LGE_LGE_LATE_PARAMS["log_cho_lge_lge_late_hi"],
+):
+    return _sigmoid(lgm, 13, 0.5, log_cho_lge_lge_late_lo, log_cho_lge_lge_late_hi)
+
+
+@jjit
+def _log_cho_lge_lge_early(
+    lgm,
+    log_cho_lge_lge_early_lo=LOG_CHO_LGE_LGE_EARLY_PARAMS["log_cho_lge_lge_early_lo"],
+    log_cho_lge_lge_early_hi=LOG_CHO_LGE_LGE_EARLY_PARAMS["log_cho_lge_lge_early_hi"],
+):
+    return _sigmoid(lgm, 13, 0.5, log_cho_lge_lge_early_lo, log_cho_lge_lge_early_hi)
+
+
+@jjit
+def _sigmoid(x, x0, k, ymin, ymax):
+    height_diff = ymax - ymin
+    return ymin + height_diff / (1 + jnp.exp(-k * (x - x0)))
+
+
+@jjit
+def _lge_vs_lgm_late(
+    lgm,
+    lge_late_lo=LGE_LATE_PARAMS["lge_late_lo"],
+    lge_late_hi=LGE_LATE_PARAMS["lge_late_hi"],
+):
+    return _sigmoid(lgm, 13, 0.5, lge_late_lo, lge_late_hi)
+
+
+@jjit
+def _lge_vs_lgm_early(
+    lgm,
+    lge_early_lo=LGE_EARLY_PARAMS["lge_early_lo"],
+    lge_early_hi=LGE_EARLY_PARAMS["lge_early_hi"],
+):
+    return _sigmoid(lgm, 13, 0.5, lge_early_lo, lge_early_hi)
+
+
+@jjit
+def _lgl_vs_lgm_late(
+    lgm,
+    lgl_late_lo=LGL_LATE_PARAMS["lgl_late_lo"],
+    lgl_late_hi=LGL_LATE_PARAMS["lgl_late_hi"],
+):
+    return _sigmoid(lgm, 13, 0.5, lgl_late_lo, lgl_late_hi)
+
+
+@jjit
+def _lgl_vs_lgm_early(
+    lgm,
+    lgl_early_lo=LGL_EARLY_PARAMS["lgl_early_lo"],
+    lgl_early_hi=LGL_EARLY_PARAMS["lgl_early_hi"],
+):
+    return _sigmoid(lgm, 12.5, 1.5, lgl_early_lo, lgl_early_hi)
+
+
+@jjit
+def _x0_vs_lgm_late(
+    lgm,
+    x0_late=X0_LATE_PARAMS["x0_late"],
+):
+    return jnp.zeros_like(lgm) + x0_late
+
+
+@jjit
+def _x0_vs_lgm_early(
+    lgm,
+    x0_early=X0_EARLY_PARAMS["x0_early"],
+):
+    return jnp.zeros_like(lgm) + x0_early
+
+
+@jjit
+def _mah_pdf_early(
+    lgm,
+    lge,
+    lgl,
+    x0,
+    lge_early_lo=LGE_EARLY_PARAMS["lge_early_lo"],
+    lge_early_hi=LGE_EARLY_PARAMS["lge_early_hi"],
+    lgl_early_lo=LGL_EARLY_PARAMS["lgl_early_lo"],
+    lgl_early_hi=LGL_EARLY_PARAMS["lgl_early_hi"],
+    x0_early=X0_EARLY_PARAMS["x0_early"],
+    log_cho_lge_lge_early_lo=LOG_CHO_LGE_LGE_EARLY_PARAMS["log_cho_lge_lge_early_lo"],
+    log_cho_lge_lge_early_hi=LOG_CHO_LGE_LGE_EARLY_PARAMS["log_cho_lge_lge_early_hi"],
+    log_cho_lgl_lgl_early_lo=LOG_CHO_LGL_LGL_EARLY_PARAMS["log_cho_lgl_lgl_early_lo"],
+    log_cho_lgl_lgl_early_hi=LOG_CHO_LGL_LGL_EARLY_PARAMS["log_cho_lgl_lgl_early_hi"],
+    log_cho_x0_x0_early=LOG_CHO_X0_X0_EARLY_PARAMS["log_cho_x0_x0_early"],
+    cho_lge_lgl_early=CHO_LGE_LGL_EARLY_PARAMS["cho_lge_lgl_early"],
+    cho_lge_x0_early=CHO_LGE_X0_EARLY_PARAMS["cho_lge_x0_early"],
+    cho_lgl_x0_early=CHO_LGL_X0_EARLY_PARAMS["cho_lgl_x0_early"],
+):
+    X = jnp.array((lge, lgl, x0)).astype("f4").T
+    mu = _get_mean_mah_params_early(
+        lgm,
+        lge_early_lo,
+        lge_early_hi,
+        lgl_early_lo,
+        lgl_early_hi,
+        x0_early,
+    )
+    cov = _get_cov_early(
+        lgm,
+        log_cho_lge_lge_early_lo,
+        log_cho_lge_lge_early_hi,
+        log_cho_lgl_lgl_early_lo,
+        log_cho_lgl_lgl_early_hi,
+        log_cho_x0_x0_early,
+        cho_lge_lgl_early,
+        cho_lge_x0_early,
+        cho_lgl_x0_early,
+    )
+    return jnorm.pdf(X, mu, cov)
+
+
+@jjit
+def _mah_pdf_late(
+    lgm,
+    lge,
+    lgl,
+    x0,
+    lge_late_lo=LGE_LATE_PARAMS["lge_late_lo"],
+    lge_late_hi=LGE_LATE_PARAMS["lge_late_hi"],
+    lgl_late_lo=LGL_LATE_PARAMS["lgl_late_lo"],
+    lgl_late_hi=LGL_LATE_PARAMS["lgl_late_hi"],
+    x0_late=X0_LATE_PARAMS["x0_late"],
+    log_cho_lge_lge_late_lo=LOG_CHO_LGE_LGE_LATE_PARAMS["log_cho_lge_lge_late_lo"],
+    log_cho_lge_lge_late_hi=LOG_CHO_LGE_LGE_LATE_PARAMS["log_cho_lge_lge_late_hi"],
+    log_cho_lgl_lgl_late_lo=LOG_CHO_LGL_LGL_LATE_PARAMS["log_cho_lgl_lgl_late_lo"],
+    log_cho_lgl_lgl_late_hi=LOG_CHO_LGL_LGL_LATE_PARAMS["log_cho_lgl_lgl_late_hi"],
+    log_cho_x0_x0_late=LOG_CHO_X0_X0_LATE_PARAMS["log_cho_x0_x0_late"],
+    cho_lge_lgl_late=CHO_LGE_LGL_LATE_PARAMS["cho_lge_lgl_late"],
+    cho_lge_x0_late=CHO_LGE_X0_LATE_PARAMS["cho_lge_x0_late"],
+    cho_lgl_x0_late=CHO_LGL_X0_LATE_PARAMS["cho_lgl_x0_late"],
+):
+    X = jnp.array((lge, lgl, x0)).astype("f4").T
+    mu = _get_mean_mah_params_late(
+        lgm,
+        lge_late_lo,
+        lge_late_hi,
+        lgl_late_lo,
+        lgl_late_hi,
+        x0_late,
+    )
+    cov = _get_cov_late(
+        lgm,
+        log_cho_lge_lge_late_lo,
+        log_cho_lge_lge_late_hi,
+        log_cho_lgl_lgl_late_lo,
+        log_cho_lgl_lgl_late_hi,
+        log_cho_x0_x0_late,
+        cho_lge_lgl_late,
+        cho_lge_x0_late,
+        cho_lgl_x0_late,
+    )
+    return jnorm.pdf(X, mu, cov)

--- a/diffmah/tests/test_halo_population_assembly.py
+++ b/diffmah/tests/test_halo_population_assembly.py
@@ -1,0 +1,29 @@
+"""
+"""
+import numpy as np
+from ..halo_population_assembly import _get_average_halo_histories
+
+
+def test_get_average_halo_histories():
+    """Verify that the _get_average_halo_histories returns reasonable arrays."""
+    n_early, n_late, n_x0 = 10, 15, 20
+    lge_min, lge_max = -1.5, 1.5
+    lgl_min, lgl_max = -2, 1
+    x0_min, x0_max = -1.0, 1
+    lge_arr = np.linspace(lge_min, lge_max, n_early)
+    lgl_arr = np.linspace(lgl_min, lgl_max, n_late)
+    x0_arr = np.linspace(x0_min, x0_max, n_x0)
+    tarr = np.linspace(1, 13.8, 25)
+    lgt_arr = np.log10(tarr)
+    lgmp_arr = np.array((11.25, 11.75, 12, 12.5, 13, 13.5, 14, 14.5))
+    _res = _get_average_halo_histories(lgt_arr, lgmp_arr, lge_arr, lgl_arr, x0_arr)
+    mean_dmhdts, mean_log_mahs, std_dmhdt, std_log_mah = _res
+
+    #  Average halo MAHs should agree at t=today
+    assert np.allclose(mean_log_mahs[:, -1], lgmp_arr, atol=0.01)
+
+    # Average halo MAHs should monotonically increase
+    assert np.all(np.diff(mean_log_mahs, axis=1) > 0)
+
+    # Average halo accretion rates should monotonically increase with present-day mass
+    assert np.all(np.diff(mean_dmhdts[:, -1]) > 0)


### PR DESCRIPTION
This PR brings in a new model for the mass assembly history of halo populations across the mass range 11 < logMpeak < 15. The model for fitting individual halos is the same as always:

![CodeCogsEqn (8)](https://user-images.githubusercontent.com/6951595/113743048-d40a4300-96c8-11eb-8417-11184768a862.gif)

Before #72 we were setting t_0 to be the first time the halo attained its peak mass, whereas now t_0=13.8 for all halos. The function α(t) is just the usual sigmoid function that varies smoothly from an early-time asymptotic value (alpha_early) to a late-time asymptotic value (alpha_late), with a characteristic transition between the two regimes at x0.

![CodeCogsEqn (9)](https://user-images.githubusercontent.com/6951595/113743637-817d5680-96c9-11eb-90f4-48f46b22f276.gif)


When fitting the diffmah model to Rockstar histories using the alternate fitting configuration brought in with PR #72, the distribution of best-fit parameters looks like the following:

![lge_vs_lgl_allm](https://user-images.githubusercontent.com/6951595/113739150-221d4780-96c5-11eb-99e6-65db61d5bb6b.png)

This highly non-Gaussian structure looks complicated to model. But wait, there's more! The x0 distribution shows a clear bimodality:

![x0_bimodal_pdf](https://user-images.githubusercontent.com/6951595/113739395-5c86e480-96c5-11eb-8411-0b9f42c972cf.png)

As a reminder for the meaning of x0, this plot shows that halos with larger x0 are later-forming, and halos with smaller x0 are earlier-forming:

![x0_interpretaish](https://user-images.githubusercontent.com/6951595/113741194-061aa580-96c7-11eb-885e-b06eabbef14f.png)

The mass-independence of the bimodality in x0 is actually a simplifying feature that we can exploit, particularly because of how strongly the alpha_early-alpha_late covariance depends on which hump in the bimodality, shown pretty strikingly in this plot, which is the exact same data in the first plot, but now color-coded according to whether the halos have x0 < 0.15 (early-forming plotted in orange) or x0 > 0.15 (later-forming in purple):

![lge_vs_lgl_allm_bimodal](https://user-images.githubusercontent.com/6951595/113741628-75909500-96c7-11eb-8b62-bb6823f75b77.png)

Wow! The value of x0 more or less _entirely_ determines which alpha_early-alpha_late sequence the halos belong to. The next two plots show more encouraging results for the potential to leverage this simplification.

First, the mass-dependence of the bimodality abundance is really smooth and gradual:

![x0_bimodality_fraction](https://user-images.githubusercontent.com/6951595/113742282-154e2300-96c8-11eb-8e3a-b1d401c76aab.png)

The second piece of good news is that the mass-dependence of the alpha_early-alpha_late structure of these two populations appears to be very simple. The color scheme in this scatter plot is the same as above, so purple --> red shows low-->high mass. Notice that there is no real change to the tilt of the covariance, just a shift in the means, a dilation/contraction of the determinants, and maybe a small change to the axis ratios. That looked simple enough to model, so I took a crack at it in this PR. Details to follow.

![x0_bimodal_pdf_twopanel](https://user-images.githubusercontent.com/6951595/113742443-40d10d80-96c8-11eb-9bf7-444d3f10adfb.png)




