### PR TITLE
Updated bimodal PDF model

### DIFF
--- a/diffmah/halo_population_assembly.py
+++ b/diffmah/halo_population_assembly.py
@@ -1,23 +1,21 @@
-"""Calculate differentiable average halo histories."""
+"""Calculate differentiable probabilistic history of an individual halo."""
 from jax import numpy as jnp
 from jax import jit as jjit
 from jax import vmap
 from jax.scipy.stats import multivariate_normal as jnorm
 from .individual_halo_assembly import _calc_halo_history, DEFAULT_MAH_PARAMS
 from .mah_pop_param_model import frac_late_forming
+from .mah_pop_param_model import _get_mean_mah_params_early
+from .mah_pop_param_model import _get_mean_mah_params_late
 from .mah_pop_param_model import _get_cov_early, _get_cov_late
-from .mah_pop_param_model import _get_mean_mah_params_early, _get_mean_mah_params_late
-
-from .mah_pop_param_model import FRAC_LATE_FORMING_PARAMS
-from .mah_pop_param_model import MEAN_PARAMS_EARLY, MEAN_PARAMS_LATE
-from .mah_pop_param_model import COV_PARAMS_EARLY, COV_PARAMS_LATE
+from .mah_pop_param_model import DEFAULT_MAH_PDF_PARAMS
 
 TODAY = 13.8
 LGT0 = jnp.log10(TODAY)
+CLIP = -10.0
 
 
-_g0 = vmap(_calc_halo_history, in_axes=(None, None, 0, *[None] * 4))
-_g1 = vmap(_g0, in_axes=(*[None] * 5, 0, None))
+_g1 = vmap(_calc_halo_history, in_axes=(*[None] * 5, 0, None))
 _g2 = vmap(_g1, in_axes=(*[None] * 5, None, 0))
 _halo_history_integrand = jjit(vmap(_g2, in_axes=(*[None] * 3, 0, *[None] * 3)))
 
@@ -27,102 +25,129 @@ def _multivariate_normal_pdf_kernel(lge, lgl, x0, mu, cov):
     return jnorm.pdf(X, mu, cov)
 
 
-_g0 = vmap(_multivariate_normal_pdf_kernel, in_axes=(None, None, None, 0, 0))
-_g1 = vmap(_g0, in_axes=(0, None, None, None, None))
+_g1 = vmap(_multivariate_normal_pdf_kernel, in_axes=(0, None, None, None, None))
 _g2 = vmap(_g1, in_axes=(None, 0, None, None, None))
 _get_pdf_weights_kern = vmap(_g2, in_axes=(None, None, 0, None, None))
 
 
 @jjit
-def _get_mah_weights(lge_arr, lgl_arr, x0_arr, mu_arr, cov_arr):
-    _pdf = _get_pdf_weights_kern(lge_arr, lgl_arr, x0_arr, mu_arr, cov_arr)
-    n_halos = _pdf.shape[-1]
-    _norm = jnp.sum(_pdf, axis=(0, 1, 2))
-    _norm = jnp.where(_norm == 0, 1.0, _norm)
-    pdf = _pdf / _norm.reshape((1, 1, 1, n_halos))
-    return pdf
+def _get_mah_weights(lge_arr, lgl_arr, x0_arr, mu, cov):
+    _pdf = _get_pdf_weights_kern(lge_arr, lgl_arr, x0_arr, mu, cov)
+    return _pdf / jnp.sum(_pdf, axis=(0, 1, 2))
 
 
 @jjit
-def _get_halo_mahs(
+def _get_bimodal_halo_history_kern(
     logt,
-    logmp_arr,
+    logmp,
     lge_arr,
     lgl_arr,
     x0_arr,
-    k=DEFAULT_MAH_PARAMS["mah_k"],
-    logtmp=LGT0,
-):
-    dmhdt, log_mah = _halo_history_integrand(
-        logt, logtmp, logmp_arr, x0_arr, k, 10 ** lge_arr, 10 ** lgl_arr
-    )
-    return dmhdt, log_mah
-
-
-@jjit
-def _get_average_halo_histories(
-    logt,
-    logmp_arr,
-    lge_arr,
-    lgl_arr,
-    x0_arr,
-    frac_late_forming_lo=FRAC_LATE_FORMING_PARAMS["frac_late_forming_lo"],
-    frac_late_forming_hi=FRAC_LATE_FORMING_PARAMS["frac_late_forming_hi"],
-    lge_early_lo=MEAN_PARAMS_EARLY["lge_early_lo"],
-    lge_early_hi=MEAN_PARAMS_EARLY["lge_early_hi"],
-    lgl_early_lo=MEAN_PARAMS_EARLY["lgl_early_lo"],
-    lgl_early_hi=MEAN_PARAMS_EARLY["lgl_early_hi"],
-    x0_early=MEAN_PARAMS_EARLY["x0_early"],
-    lge_late_lo=MEAN_PARAMS_LATE["lge_late_lo"],
-    lge_late_hi=MEAN_PARAMS_LATE["lge_late_hi"],
-    lgl_late_lo=MEAN_PARAMS_LATE["lgl_late_lo"],
-    lgl_late_hi=MEAN_PARAMS_LATE["lgl_late_hi"],
-    x0_late=MEAN_PARAMS_LATE["x0_late"],
-    log_cho_lge_lge_early_lo=COV_PARAMS_EARLY["log_cho_lge_lge_early_lo"],
-    log_cho_lge_lge_early_hi=COV_PARAMS_EARLY["log_cho_lge_lge_early_hi"],
-    log_cho_lgl_lgl_early_lo=COV_PARAMS_EARLY["log_cho_lgl_lgl_early_lo"],
-    log_cho_lgl_lgl_early_hi=COV_PARAMS_EARLY["log_cho_lgl_lgl_early_hi"],
-    log_cho_x0_x0_early=COV_PARAMS_EARLY["log_cho_x0_x0_early"],
-    cho_lge_lgl_early=COV_PARAMS_EARLY["cho_lge_lgl_early"],
-    cho_lge_x0_early=COV_PARAMS_EARLY["cho_lge_x0_early"],
-    cho_lgl_x0_early=COV_PARAMS_EARLY["cho_lgl_x0_early"],
-    log_cho_lge_lge_late_lo=COV_PARAMS_LATE["log_cho_lge_lge_late_lo"],
-    log_cho_lge_lge_late_hi=COV_PARAMS_LATE["log_cho_lge_lge_late_hi"],
-    log_cho_lgl_lgl_late_lo=COV_PARAMS_LATE["log_cho_lgl_lgl_late_lo"],
-    log_cho_lgl_lgl_late_hi=COV_PARAMS_LATE["log_cho_lgl_lgl_late_hi"],
-    log_cho_x0_x0_late=COV_PARAMS_LATE["log_cho_x0_x0_late"],
-    cho_lge_lgl_late=COV_PARAMS_LATE["cho_lge_lgl_late"],
-    cho_lge_x0_late=COV_PARAMS_LATE["cho_lge_x0_late"],
-    cho_lgl_x0_late=COV_PARAMS_LATE["cho_lgl_x0_late"],
+    frac_late,
+    mu_early,
+    mu_late,
+    cov_early,
+    cov_late,
     k=DEFAULT_MAH_PARAMS["mah_k"],
     logtmp=LGT0,
 ):
     dmhdts, log_mahs = _halo_history_integrand(
-        logt, logtmp, logmp_arr, x0_arr, k, 10 ** lge_arr, 10 ** lgl_arr
+        logt, logtmp, logmp, x0_arr, k, 10 ** lge_arr, 10 ** lgl_arr
     )
     mahs = 10 ** log_mahs
 
+    weights_early = _get_mah_weights(lge_arr, lgl_arr, x0_arr, mu_early, cov_early)
+    weights_late = _get_mah_weights(lge_arr, lgl_arr, x0_arr, mu_late, cov_late)
+
+    n_x0, n_late, n_early, n_t = mahs.shape
+    weights_early = weights_early.reshape((n_x0, n_late, n_early, 1))
+    weights_late = weights_late.reshape((n_x0, n_late, n_early, 1))
+
+    w = frac_late * weights_late + (1 - frac_late) * weights_early
+    w_mahs = mahs * w
+    w_dmhdts = dmhdts * w
+
+    mean_dmhdt = jnp.sum(w_dmhdts, axis=(0, 1, 2))
+    mean_mah = jnp.sum(w_mahs, axis=(0, 1, 2))
+
+    delta_dmhdt_sq = (dmhdts - mean_dmhdt) ** 2
+    delta_mah_sq = (mahs - mean_mah) ** 2
+
+    variance_dmhdt = jnp.sum(delta_dmhdt_sq * w, axis=(0, 1, 2))
+    variance_mah = jnp.sum(delta_mah_sq * w, axis=(0, 1, 2))
+
+    return mean_dmhdt, mean_mah, variance_dmhdt, variance_mah
+
+
+_a = (None, 0, None, None, None, *[0] * 5)
+_multimass_bimodal_halo_history_kern = jjit(
+    vmap(_get_bimodal_halo_history_kern, in_axes=_a)
+)
+
+
+@jjit
+def _get_bimodal_halo_history(
+    logt,
+    logmp_arr,
+    lge_arr,
+    lgl_arr,
+    x0_arr,
+    frac_late_forming_lo=DEFAULT_MAH_PDF_PARAMS["frac_late_forming_lo"],
+    frac_late_forming_hi=DEFAULT_MAH_PDF_PARAMS["frac_late_forming_hi"],
+    lge_early_lo=DEFAULT_MAH_PDF_PARAMS["lge_early_lo"],
+    lge_early_hi=DEFAULT_MAH_PDF_PARAMS["lge_early_hi"],
+    lgl_early_lo=DEFAULT_MAH_PDF_PARAMS["lgl_early_lo"],
+    lgl_early_hi=DEFAULT_MAH_PDF_PARAMS["lgl_early_hi"],
+    x0_early_lo=DEFAULT_MAH_PDF_PARAMS["x0_early_lo"],
+    x0_early_hi=DEFAULT_MAH_PDF_PARAMS["x0_early_hi"],
+    log_cho_lge_lge_early_lo=DEFAULT_MAH_PDF_PARAMS["log_cho_lge_lge_early_lo"],
+    log_cho_lge_lge_early_hi=DEFAULT_MAH_PDF_PARAMS["log_cho_lge_lge_early_hi"],
+    log_cho_lgl_lgl_early_lo=DEFAULT_MAH_PDF_PARAMS["log_cho_lgl_lgl_early_lo"],
+    log_cho_lgl_lgl_early_hi=DEFAULT_MAH_PDF_PARAMS["log_cho_lgl_lgl_early_hi"],
+    log_cho_x0_x0_early=DEFAULT_MAH_PDF_PARAMS["log_cho_x0_x0_early"],
+    cho_lge_lgl_early=DEFAULT_MAH_PDF_PARAMS["cho_lge_lgl_early"],
+    cho_lge_x0_early=DEFAULT_MAH_PDF_PARAMS["cho_lge_x0_early"],
+    cho_lgl_x0_early=DEFAULT_MAH_PDF_PARAMS["cho_lgl_x0_early"],
+    lge_late_lo=DEFAULT_MAH_PDF_PARAMS["lge_late_lo"],
+    lge_late_hi=DEFAULT_MAH_PDF_PARAMS["lge_late_hi"],
+    lgl_late_lo=DEFAULT_MAH_PDF_PARAMS["lgl_late_lo"],
+    lgl_late_hi=DEFAULT_MAH_PDF_PARAMS["lgl_late_hi"],
+    x0_late_lo=DEFAULT_MAH_PDF_PARAMS["x0_late_lo"],
+    x0_late_hi=DEFAULT_MAH_PDF_PARAMS["x0_late_hi"],
+    log_cho_lge_lge_late_lo=DEFAULT_MAH_PDF_PARAMS["log_cho_lge_lge_late_lo"],
+    log_cho_lge_lge_late_hi=DEFAULT_MAH_PDF_PARAMS["log_cho_lge_lge_late_hi"],
+    log_cho_lgl_lgl_late_lo=DEFAULT_MAH_PDF_PARAMS["log_cho_lgl_lgl_late_lo"],
+    log_cho_lgl_lgl_late_hi=DEFAULT_MAH_PDF_PARAMS["log_cho_lgl_lgl_late_hi"],
+    log_cho_x0_x0_late=DEFAULT_MAH_PDF_PARAMS["log_cho_x0_x0_late"],
+    cho_lge_lgl_late=DEFAULT_MAH_PDF_PARAMS["cho_lge_lgl_late"],
+    cho_lge_x0_late=DEFAULT_MAH_PDF_PARAMS["cho_lge_x0_late"],
+    cho_lgl_x0_late=DEFAULT_MAH_PDF_PARAMS["cho_lgl_x0_late"],
+    k=DEFAULT_MAH_PARAMS["mah_k"],
+    logtmp=LGT0,
+):
+    frac_late = frac_late_forming(logmp_arr, frac_late_forming_lo, frac_late_forming_hi)
+
     lge_early, lgl_early, x0_early = _get_mean_mah_params_early(
-        logmp_arr, lge_early_lo, lge_early_hi, lgl_early_lo, lgl_early_hi, x0_early
+        logmp_arr,
+        lge_early_lo,
+        lge_early_hi,
+        lgl_early_lo,
+        lgl_early_hi,
+        x0_early_lo,
+        x0_early_hi,
     )
     means_early = jnp.array((lge_early, lgl_early, x0_early)).T
-
     lge_late, lgl_late, x0_late = _get_mean_mah_params_late(
-        logmp_arr, lge_late_lo, lge_late_hi, lgl_late_lo, lgl_late_hi, x0_late
+        logmp_arr,
+        lge_late_lo,
+        lge_late_hi,
+        lgl_late_lo,
+        lgl_late_hi,
+        x0_late_lo,
+        x0_late_hi,
     )
     means_late = jnp.array((lge_late, lgl_late, x0_late)).T
 
-    covs_late = _get_cov_late(
-        logmp_arr,
-        log_cho_lge_lge_late_lo,
-        log_cho_lge_lge_late_hi,
-        log_cho_lgl_lgl_late_lo,
-        log_cho_lgl_lgl_late_hi,
-        log_cho_x0_x0_late,
-        cho_lge_lgl_late,
-        cho_lge_x0_late,
-        cho_lgl_x0_late,
-    )
     covs_early = _get_cov_early(
         logmp_arr,
         log_cho_lge_lge_early_lo,
@@ -134,34 +159,27 @@ def _get_average_halo_histories(
         cho_lge_x0_early,
         cho_lgl_x0_early,
     )
-
-    weights_early = _get_mah_weights(lge_arr, lgl_arr, x0_arr, means_early, covs_early)
-    weights_late = _get_mah_weights(lge_arr, lgl_arr, x0_arr, means_late, covs_late)
-
-    frac_late = frac_late_forming(logmp_arr, frac_late_forming_lo, frac_late_forming_hi)
-
-    n_x0, n_late, n_early, n_halos, n_t = log_mahs.shape
-    _wshape = n_x0, n_late, n_early, n_halos, 1
-    w_early = ((1 - frac_late) * weights_early).reshape(_wshape)
-    w_late = (frac_late * weights_late).reshape(_wshape)
-
-    w_dmhdts = dmhdts * w_early + dmhdts * w_late
-    w_mahs = mahs * w_early + mahs * w_late
-    mean_dmhdts = jnp.sum(w_dmhdts, axis=(0, 1, 2))
-    mean_mahs = jnp.sum(w_mahs, axis=(0, 1, 2))
-    mean_log_mahs = jnp.log10(mean_mahs)
-
-    delta_dmhdt_sq = (dmhdts - mean_dmhdts) ** 2
-    delta_log_mah_sq = (log_mahs - mean_log_mahs) ** 2
-
-    variance_dmhdt = jnp.sum(
-        delta_dmhdt_sq * w_early + delta_dmhdt_sq * w_late, axis=(0, 1, 2)
-    )
-    variance_log_mah = jnp.sum(
-        delta_log_mah_sq * w_early + delta_log_mah_sq * w_late, axis=(0, 1, 2)
+    covs_late = _get_cov_late(
+        logmp_arr,
+        log_cho_lge_lge_late_lo,
+        log_cho_lge_lge_late_hi,
+        log_cho_lgl_lgl_late_lo,
+        log_cho_lgl_lgl_late_hi,
+        log_cho_x0_x0_late,
+        cho_lge_lgl_late,
+        cho_lge_x0_late,
+        cho_lgl_x0_late,
     )
 
-    std_dmhdt = jnp.sqrt(variance_dmhdt)
-    std_log_mah = jnp.sqrt(variance_log_mah)
-
-    return mean_dmhdts, mean_log_mahs, std_dmhdt, std_log_mah
+    return _multimass_bimodal_halo_history_kern(
+        logt,
+        logmp_arr,
+        lge_arr,
+        lgl_arr,
+        x0_arr,
+        frac_late,
+        means_early,
+        means_late,
+        covs_early,
+        covs_late,
+    )

--- a/diffmah/mah_pop_param_model.py
+++ b/diffmah/mah_pop_param_model.py
@@ -7,62 +7,51 @@ from jax import vmap
 from jax.scipy.stats import multivariate_normal as jnorm
 
 FRAC_LATE_FORMING_PARAMS = OrderedDict(
-    frac_late_forming_lo=0.45, frac_late_forming_hi=0.58
+    frac_late_forming_lo=0.45, frac_late_forming_hi=0.65
+)
+MEAN_PARAMS_EARLY = OrderedDict(
+    lge_early_lo=0.48,
+    lge_early_hi=0.98,
+    lgl_early_lo=-0.60,
+    lgl_early_hi=0.22,
+    x0_early_lo=-0.30,
+    x0_early_hi=-0.21,
 )
 
-LGE_EARLY_PARAMS = OrderedDict(lge_early_lo=0.425, lge_early_hi=0.875)
-LGL_EARLY_PARAMS = OrderedDict(lgl_early_lo=-0.6, lgl_early_hi=0.15)
-X0_EARLY_PARAMS = OrderedDict(x0_early=-0.26)
-MEAN_PARAMS_EARLY = OrderedDict()
-MEAN_PARAMS_EARLY.update(LGE_EARLY_PARAMS)
-MEAN_PARAMS_EARLY.update(LGL_EARLY_PARAMS)
-MEAN_PARAMS_EARLY.update(X0_EARLY_PARAMS)
-
-LGE_LATE_PARAMS = OrderedDict(lge_late_lo=-0.1, lge_late_hi=0.7)
-LGL_LATE_PARAMS = OrderedDict(lgl_late_lo=-1.5, lgl_late_hi=0.4)
-X0_LATE_PARAMS = OrderedDict(x0_late=0.55)
-MEAN_PARAMS_LATE = OrderedDict()
-MEAN_PARAMS_LATE.update(LGE_LATE_PARAMS)
-MEAN_PARAMS_LATE.update(LGL_LATE_PARAMS)
-MEAN_PARAMS_LATE.update(X0_LATE_PARAMS)
-
-
-LOG_CHO_LGE_LGE_EARLY_PARAMS = OrderedDict(
-    log_cho_lge_lge_early_lo=-0.4, log_cho_lge_lge_early_hi=-0.8
+MEAN_PARAMS_LATE = OrderedDict(
+    lge_late_lo=-0.15,
+    lge_late_hi=0.76,
+    lgl_late_lo=-1.23,
+    lgl_late_hi=0.44,
+    x0_late_lo=0.42,
+    x0_late_hi=0.62,
 )
-LOG_CHO_LGL_LGL_EARLY_PARAMS = OrderedDict(
-    log_cho_lgl_lgl_early_lo=-0.25, log_cho_lgl_lgl_early_hi=-1.05
+COV_PARAMS_EARLY = OrderedDict(
+    log_cho_lge_lge_early_lo=-0.50,
+    log_cho_lge_lge_early_hi=-0.79,
+    log_cho_lgl_lgl_early_lo=-0.16,
+    log_cho_lgl_lgl_early_hi=-1.14,
+    log_cho_x0_x0_early=-0.97,
+    cho_lge_lgl_early=-0.05,
+    cho_lge_x0_early=-0.05,
+    cho_lgl_x0_early=-0.11,
 )
-LOG_CHO_X0_X0_EARLY_PARAMS = OrderedDict(log_cho_x0_x0_early=-0.85)
-CHO_LGE_LGL_EARLY_PARAMS = OrderedDict(cho_lge_lgl_early=-0.08)
-CHO_LGE_X0_EARLY_PARAMS = OrderedDict(cho_lge_x0_early=-0.1)
-CHO_LGL_X0_EARLY_PARAMS = OrderedDict(cho_lgl_x0_early=-0.08)
-COV_PARAMS_EARLY = OrderedDict()
-COV_PARAMS_EARLY.update(LOG_CHO_LGE_LGE_EARLY_PARAMS)
-COV_PARAMS_EARLY.update(LOG_CHO_LGL_LGL_EARLY_PARAMS)
-COV_PARAMS_EARLY.update(LOG_CHO_X0_X0_EARLY_PARAMS)
-COV_PARAMS_EARLY.update(CHO_LGE_LGL_EARLY_PARAMS)
-COV_PARAMS_EARLY.update(CHO_LGE_X0_EARLY_PARAMS)
-COV_PARAMS_EARLY.update(CHO_LGL_X0_EARLY_PARAMS)
-
-
-LOG_CHO_LGE_LGE_LATE_PARAMS = OrderedDict(
-    log_cho_lge_lge_late_lo=-0.675, log_cho_lge_lge_late_hi=-1.125
+COV_PARAMS_LATE = OrderedDict(
+    log_cho_lge_lge_late_lo=-0.51,
+    log_cho_lge_lge_late_hi=-1.34,
+    log_cho_lgl_lgl_late_lo=-0.35,
+    log_cho_lgl_lgl_late_hi=-0.44,
+    log_cho_x0_x0_late=-0.80,
+    cho_lge_lgl_late=-0.02,
+    cho_lge_x0_late=0.00,
+    cho_lgl_x0_late=0.02,
 )
-LOG_CHO_LGL_LGL_LATE_PARAMS = OrderedDict(
-    log_cho_lgl_lgl_late_lo=-0.3, log_cho_lgl_lgl_late_hi=-0.45
-)
-LOG_CHO_X0_X0_LATE_PARAMS = OrderedDict(log_cho_x0_x0_late=-0.75)
-CHO_LGE_LGL_LATE_PARAMS = OrderedDict(cho_lge_lgl_late=-0.1)
-CHO_LGE_X0_LATE_PARAMS = OrderedDict(cho_lge_x0_late=-0.08)
-CHO_LGL_X0_LATE_PARAMS = OrderedDict(cho_lgl_x0_late=-0.02)
-COV_PARAMS_LATE = OrderedDict()
-COV_PARAMS_LATE.update(LOG_CHO_LGE_LGE_LATE_PARAMS)
-COV_PARAMS_LATE.update(LOG_CHO_LGL_LGL_LATE_PARAMS)
-COV_PARAMS_LATE.update(LOG_CHO_X0_X0_LATE_PARAMS)
-COV_PARAMS_LATE.update(CHO_LGE_LGL_LATE_PARAMS)
-COV_PARAMS_LATE.update(CHO_LGE_X0_LATE_PARAMS)
-COV_PARAMS_LATE.update(CHO_LGL_X0_LATE_PARAMS)
+DEFAULT_MAH_PDF_PARAMS = OrderedDict()
+DEFAULT_MAH_PDF_PARAMS.update(FRAC_LATE_FORMING_PARAMS)
+DEFAULT_MAH_PDF_PARAMS.update(MEAN_PARAMS_EARLY)
+DEFAULT_MAH_PDF_PARAMS.update(COV_PARAMS_EARLY)
+DEFAULT_MAH_PDF_PARAMS.update(MEAN_PARAMS_LATE)
+DEFAULT_MAH_PDF_PARAMS.update(COV_PARAMS_LATE)
 
 
 def _get_cov_scalar(
@@ -90,14 +79,14 @@ _get_cov_vmap = jjit(vmap(_get_cov_scalar, in_axes=(0, 0, 0, 0, 0, 0)))
 @jjit
 def _get_cov_early(
     lgm,
-    log_cho_lge_lge_early_lo=LOG_CHO_LGE_LGE_EARLY_PARAMS["log_cho_lge_lge_early_lo"],
-    log_cho_lge_lge_early_hi=LOG_CHO_LGE_LGE_EARLY_PARAMS["log_cho_lge_lge_early_hi"],
-    log_cho_lgl_lgl_early_lo=LOG_CHO_LGL_LGL_EARLY_PARAMS["log_cho_lgl_lgl_early_lo"],
-    log_cho_lgl_lgl_early_hi=LOG_CHO_LGL_LGL_EARLY_PARAMS["log_cho_lgl_lgl_early_hi"],
-    log_cho_x0_x0_early=LOG_CHO_X0_X0_EARLY_PARAMS["log_cho_x0_x0_early"],
-    cho_lge_lgl_early=CHO_LGE_LGL_EARLY_PARAMS["cho_lge_lgl_early"],
-    cho_lge_x0_early=CHO_LGE_X0_EARLY_PARAMS["cho_lge_x0_early"],
-    cho_lgl_x0_early=CHO_LGL_X0_EARLY_PARAMS["cho_lgl_x0_early"],
+    log_cho_lge_lge_early_lo=COV_PARAMS_EARLY["log_cho_lge_lge_early_lo"],
+    log_cho_lge_lge_early_hi=COV_PARAMS_EARLY["log_cho_lge_lge_early_hi"],
+    log_cho_lgl_lgl_early_lo=COV_PARAMS_EARLY["log_cho_lgl_lgl_early_lo"],
+    log_cho_lgl_lgl_early_hi=COV_PARAMS_EARLY["log_cho_lgl_lgl_early_hi"],
+    log_cho_x0_x0_early=COV_PARAMS_EARLY["log_cho_x0_x0_early"],
+    cho_lge_lgl_early=COV_PARAMS_EARLY["cho_lge_lgl_early"],
+    cho_lge_x0_early=COV_PARAMS_EARLY["cho_lge_x0_early"],
+    cho_lgl_x0_early=COV_PARAMS_EARLY["cho_lgl_x0_early"],
 ):
     _res = _get_cov_mah_params_early(
         lgm,
@@ -116,14 +105,14 @@ def _get_cov_early(
 @jjit
 def _get_cov_late(
     lgm,
-    log_cho_lge_lge_late_lo=LOG_CHO_LGE_LGE_LATE_PARAMS["log_cho_lge_lge_late_lo"],
-    log_cho_lge_lge_late_hi=LOG_CHO_LGE_LGE_LATE_PARAMS["log_cho_lge_lge_late_hi"],
-    log_cho_lgl_lgl_late_lo=LOG_CHO_LGL_LGL_LATE_PARAMS["log_cho_lgl_lgl_late_lo"],
-    log_cho_lgl_lgl_late_hi=LOG_CHO_LGL_LGL_LATE_PARAMS["log_cho_lgl_lgl_late_hi"],
-    log_cho_x0_x0_late=LOG_CHO_X0_X0_LATE_PARAMS["log_cho_x0_x0_late"],
-    cho_lge_lgl_late=CHO_LGE_LGL_LATE_PARAMS["cho_lge_lgl_late"],
-    cho_lge_x0_late=CHO_LGE_X0_LATE_PARAMS["cho_lge_x0_late"],
-    cho_lgl_x0_late=CHO_LGL_X0_LATE_PARAMS["cho_lgl_x0_late"],
+    log_cho_lge_lge_late_lo=COV_PARAMS_LATE["log_cho_lge_lge_late_lo"],
+    log_cho_lge_lge_late_hi=COV_PARAMS_LATE["log_cho_lge_lge_late_hi"],
+    log_cho_lgl_lgl_late_lo=COV_PARAMS_LATE["log_cho_lgl_lgl_late_lo"],
+    log_cho_lgl_lgl_late_hi=COV_PARAMS_LATE["log_cho_lgl_lgl_late_hi"],
+    log_cho_x0_x0_late=COV_PARAMS_LATE["log_cho_x0_x0_late"],
+    cho_lge_lgl_late=COV_PARAMS_LATE["cho_lge_lgl_late"],
+    cho_lge_x0_late=COV_PARAMS_LATE["cho_lge_x0_late"],
+    cho_lgl_x0_late=COV_PARAMS_LATE["cho_lgl_x0_late"],
 ):
     _res = _get_cov_mah_params_late(
         lgm,
@@ -142,14 +131,14 @@ def _get_cov_late(
 @jjit
 def _get_cov_mah_params_early(
     lgm,
-    log_cho_lge_lge_early_lo=LOG_CHO_LGE_LGE_EARLY_PARAMS["log_cho_lge_lge_early_lo"],
-    log_cho_lge_lge_early_hi=LOG_CHO_LGE_LGE_EARLY_PARAMS["log_cho_lge_lge_early_hi"],
-    log_cho_lgl_lgl_early_lo=LOG_CHO_LGL_LGL_EARLY_PARAMS["log_cho_lgl_lgl_early_lo"],
-    log_cho_lgl_lgl_early_hi=LOG_CHO_LGL_LGL_EARLY_PARAMS["log_cho_lgl_lgl_early_hi"],
-    log_cho_x0_x0_early=LOG_CHO_X0_X0_EARLY_PARAMS["log_cho_x0_x0_early"],
-    cho_lge_lgl_early=CHO_LGE_LGL_EARLY_PARAMS["cho_lge_lgl_early"],
-    cho_lge_x0_early=CHO_LGE_X0_EARLY_PARAMS["cho_lge_x0_early"],
-    cho_lgl_x0_early=CHO_LGL_X0_EARLY_PARAMS["cho_lgl_x0_early"],
+    log_cho_lge_lge_early_lo=COV_PARAMS_EARLY["log_cho_lge_lge_early_lo"],
+    log_cho_lge_lge_early_hi=COV_PARAMS_EARLY["log_cho_lge_lge_early_hi"],
+    log_cho_lgl_lgl_early_lo=COV_PARAMS_EARLY["log_cho_lgl_lgl_early_lo"],
+    log_cho_lgl_lgl_early_hi=COV_PARAMS_EARLY["log_cho_lgl_lgl_early_hi"],
+    log_cho_x0_x0_early=COV_PARAMS_EARLY["log_cho_x0_x0_early"],
+    cho_lge_lgl_early=COV_PARAMS_EARLY["cho_lge_lgl_early"],
+    cho_lge_x0_early=COV_PARAMS_EARLY["cho_lge_x0_early"],
+    cho_lgl_x0_early=COV_PARAMS_EARLY["cho_lgl_x0_early"],
 ):
     log10_lge_lge = _log_cho_lge_lge_early(
         lgm, log_cho_lge_lge_early_lo, log_cho_lge_lge_early_hi
@@ -168,14 +157,14 @@ def _get_cov_mah_params_early(
 @jjit
 def _get_cov_mah_params_late(
     lgm,
-    log_cho_lge_lge_late_lo=LOG_CHO_LGE_LGE_LATE_PARAMS["log_cho_lge_lge_late_lo"],
-    log_cho_lge_lge_late_hi=LOG_CHO_LGE_LGE_LATE_PARAMS["log_cho_lge_lge_late_hi"],
-    log_cho_lgl_lgl_late_lo=LOG_CHO_LGL_LGL_LATE_PARAMS["log_cho_lgl_lgl_late_lo"],
-    log_cho_lgl_lgl_late_hi=LOG_CHO_LGL_LGL_LATE_PARAMS["log_cho_lgl_lgl_late_hi"],
-    log_cho_x0_x0_late=LOG_CHO_X0_X0_LATE_PARAMS["log_cho_x0_x0_late"],
-    cho_lge_lgl_late=CHO_LGE_LGL_LATE_PARAMS["cho_lge_lgl_late"],
-    cho_lge_x0_late=CHO_LGE_X0_LATE_PARAMS["cho_lge_x0_late"],
-    cho_lgl_x0_late=CHO_LGL_X0_LATE_PARAMS["cho_lgl_x0_late"],
+    log_cho_lge_lge_late_lo=COV_PARAMS_LATE["log_cho_lge_lge_late_lo"],
+    log_cho_lge_lge_late_hi=COV_PARAMS_LATE["log_cho_lge_lge_late_hi"],
+    log_cho_lgl_lgl_late_lo=COV_PARAMS_LATE["log_cho_lgl_lgl_late_lo"],
+    log_cho_lgl_lgl_late_hi=COV_PARAMS_LATE["log_cho_lgl_lgl_late_hi"],
+    log_cho_x0_x0_late=COV_PARAMS_LATE["log_cho_x0_x0_late"],
+    cho_lge_lgl_late=COV_PARAMS_LATE["cho_lge_lgl_late"],
+    cho_lge_x0_late=COV_PARAMS_LATE["cho_lge_x0_late"],
+    cho_lgl_x0_late=COV_PARAMS_LATE["cho_lgl_x0_late"],
 ):
     log10_lge_lge = _log_cho_lge_lge_late(
         lgm, log_cho_lge_lge_late_lo, log_cho_lge_lge_late_hi
@@ -194,30 +183,32 @@ def _get_cov_mah_params_late(
 @jjit
 def _get_mean_mah_params_early(
     lgm,
-    lge_early_lo=LGE_EARLY_PARAMS["lge_early_lo"],
-    lge_early_hi=LGE_EARLY_PARAMS["lge_early_hi"],
-    lgl_early_lo=LGL_EARLY_PARAMS["lgl_early_lo"],
-    lgl_early_hi=LGL_EARLY_PARAMS["lgl_early_hi"],
-    x0_early=X0_EARLY_PARAMS["x0_early"],
+    lge_early_lo=MEAN_PARAMS_EARLY["lge_early_lo"],
+    lge_early_hi=MEAN_PARAMS_EARLY["lge_early_hi"],
+    lgl_early_lo=MEAN_PARAMS_EARLY["lgl_early_lo"],
+    lgl_early_hi=MEAN_PARAMS_EARLY["lgl_early_hi"],
+    x0_early_lo=MEAN_PARAMS_EARLY["x0_early_lo"],
+    x0_early_hi=MEAN_PARAMS_EARLY["x0_early_hi"],
 ):
     lge = _lge_vs_lgm_early(lgm, lge_early_lo, lge_early_hi)
     lgl = _lgl_vs_lgm_early(lgm, lgl_early_lo, lgl_early_hi)
-    x0 = _x0_vs_lgm_early(lgm, x0_early)
+    x0 = _x0_vs_lgm_early(lgm, x0_early_lo, x0_early_hi)
     return lge, lgl, x0
 
 
 @jjit
 def _get_mean_mah_params_late(
     lgm,
-    lge_late_lo=LGE_LATE_PARAMS["lge_late_lo"],
-    lge_late_hi=LGE_LATE_PARAMS["lge_late_hi"],
-    lgl_late_lo=LGL_LATE_PARAMS["lgl_late_lo"],
-    lgl_late_hi=LGL_LATE_PARAMS["lgl_late_hi"],
-    x0_late=X0_LATE_PARAMS["x0_late"],
+    lge_late_lo=MEAN_PARAMS_LATE["lge_late_lo"],
+    lge_late_hi=MEAN_PARAMS_LATE["lge_late_hi"],
+    lgl_late_lo=MEAN_PARAMS_LATE["lgl_late_lo"],
+    lgl_late_hi=MEAN_PARAMS_LATE["lgl_late_hi"],
+    x0_late_lo=MEAN_PARAMS_LATE["x0_late_lo"],
+    x0_late_hi=MEAN_PARAMS_LATE["x0_late_hi"],
 ):
     lge = _lge_vs_lgm_late(lgm, lge_late_lo, lge_late_hi)
     lgl = _lgl_vs_lgm_late(lgm, lgl_late_lo, lgl_late_hi)
-    x0 = _x0_vs_lgm_late(lgm, x0_late)
+    x0 = _x0_vs_lgm_late(lgm, x0_late_lo, x0_late_hi)
     return lge, lgl, x0
 
 
@@ -234,7 +225,7 @@ def frac_late_forming(
 @jjit
 def _cho_lgl_x0_late(
     lgm,
-    cho_lgl_x0_late=CHO_LGL_X0_LATE_PARAMS["cho_lgl_x0_late"],
+    cho_lgl_x0_late=COV_PARAMS_LATE["cho_lgl_x0_late"],
 ):
     return jnp.zeros_like(lgm) + cho_lgl_x0_late
 
@@ -242,7 +233,7 @@ def _cho_lgl_x0_late(
 @jjit
 def _cho_lgl_x0_early(
     lgm,
-    cho_lgl_x0_early=CHO_LGL_X0_EARLY_PARAMS["cho_lgl_x0_early"],
+    cho_lgl_x0_early=COV_PARAMS_EARLY["cho_lgl_x0_early"],
 ):
     return jnp.zeros_like(lgm) + cho_lgl_x0_early
 
@@ -250,7 +241,7 @@ def _cho_lgl_x0_early(
 @jjit
 def _cho_lge_x0_late(
     lgm,
-    cho_lge_x0_late=CHO_LGE_X0_LATE_PARAMS["cho_lge_x0_late"],
+    cho_lge_x0_late=COV_PARAMS_LATE["cho_lge_x0_late"],
 ):
     return jnp.zeros_like(lgm) + cho_lge_x0_late
 
@@ -258,7 +249,7 @@ def _cho_lge_x0_late(
 @jjit
 def _cho_lge_x0_early(
     lgm,
-    cho_lge_x0_early=CHO_LGE_X0_EARLY_PARAMS["cho_lge_x0_early"],
+    cho_lge_x0_early=COV_PARAMS_EARLY["cho_lge_x0_early"],
 ):
     return jnp.zeros_like(lgm) + cho_lge_x0_early
 
@@ -266,7 +257,7 @@ def _cho_lge_x0_early(
 @jjit
 def _cho_lge_lgl_late(
     lgm,
-    cho_lge_lgl_late=CHO_LGE_LGL_LATE_PARAMS["cho_lge_lgl_late"],
+    cho_lge_lgl_late=COV_PARAMS_LATE["cho_lge_lgl_late"],
 ):
     return jnp.zeros_like(lgm) + cho_lge_lgl_late
 
@@ -274,7 +265,7 @@ def _cho_lge_lgl_late(
 @jjit
 def _cho_lge_lgl_early(
     lgm,
-    cho_lge_lgl_early=CHO_LGE_LGL_EARLY_PARAMS["cho_lge_lgl_early"],
+    cho_lge_lgl_early=COV_PARAMS_EARLY["cho_lge_lgl_early"],
 ):
     return jnp.zeros_like(lgm) + cho_lge_lgl_early
 
@@ -282,7 +273,7 @@ def _cho_lge_lgl_early(
 @jjit
 def _log_cho_x0_x0_early(
     lgm,
-    log_cho_x0_x0_early=LOG_CHO_X0_X0_EARLY_PARAMS["log_cho_x0_x0_early"],
+    log_cho_x0_x0_early=COV_PARAMS_EARLY["log_cho_x0_x0_early"],
 ):
     return jnp.zeros_like(lgm) + log_cho_x0_x0_early
 
@@ -290,7 +281,7 @@ def _log_cho_x0_x0_early(
 @jjit
 def _log_cho_x0_x0_late(
     lgm,
-    log_cho_x0_x0_late=LOG_CHO_X0_X0_LATE_PARAMS["log_cho_x0_x0_late"],
+    log_cho_x0_x0_late=COV_PARAMS_LATE["log_cho_x0_x0_late"],
 ):
     return jnp.zeros_like(lgm) + log_cho_x0_x0_late
 
@@ -298,8 +289,8 @@ def _log_cho_x0_x0_late(
 @jjit
 def _log_cho_lgl_lgl_early(
     lgm,
-    log_cho_lgl_lgl_early_lo=LOG_CHO_LGL_LGL_EARLY_PARAMS["log_cho_lgl_lgl_early_lo"],
-    log_cho_lgl_lgl_early_hi=LOG_CHO_LGL_LGL_EARLY_PARAMS["log_cho_lgl_lgl_early_hi"],
+    log_cho_lgl_lgl_early_lo=COV_PARAMS_EARLY["log_cho_lgl_lgl_early_lo"],
+    log_cho_lgl_lgl_early_hi=COV_PARAMS_EARLY["log_cho_lgl_lgl_early_hi"],
 ):
     return _sigmoid(lgm, 13, 0.5, log_cho_lgl_lgl_early_lo, log_cho_lgl_lgl_early_hi)
 
@@ -307,8 +298,8 @@ def _log_cho_lgl_lgl_early(
 @jjit
 def _log_cho_lgl_lgl_late(
     lgm,
-    log_cho_lgl_lgl_late_lo=LOG_CHO_LGL_LGL_LATE_PARAMS["log_cho_lgl_lgl_late_lo"],
-    log_cho_lgl_lgl_late_hi=LOG_CHO_LGL_LGL_LATE_PARAMS["log_cho_lgl_lgl_late_hi"],
+    log_cho_lgl_lgl_late_lo=COV_PARAMS_LATE["log_cho_lgl_lgl_late_lo"],
+    log_cho_lgl_lgl_late_hi=COV_PARAMS_LATE["log_cho_lgl_lgl_late_hi"],
 ):
     return _sigmoid(lgm, 13.5, 2.0, log_cho_lgl_lgl_late_lo, log_cho_lgl_lgl_late_hi)
 
@@ -316,8 +307,8 @@ def _log_cho_lgl_lgl_late(
 @jjit
 def _log_cho_lge_lge_late(
     lgm,
-    log_cho_lge_lge_late_lo=LOG_CHO_LGE_LGE_LATE_PARAMS["log_cho_lge_lge_late_lo"],
-    log_cho_lge_lge_late_hi=LOG_CHO_LGE_LGE_LATE_PARAMS["log_cho_lge_lge_late_hi"],
+    log_cho_lge_lge_late_lo=COV_PARAMS_LATE["log_cho_lge_lge_late_lo"],
+    log_cho_lge_lge_late_hi=COV_PARAMS_LATE["log_cho_lge_lge_late_hi"],
 ):
     return _sigmoid(lgm, 13, 0.5, log_cho_lge_lge_late_lo, log_cho_lge_lge_late_hi)
 
@@ -325,8 +316,8 @@ def _log_cho_lge_lge_late(
 @jjit
 def _log_cho_lge_lge_early(
     lgm,
-    log_cho_lge_lge_early_lo=LOG_CHO_LGE_LGE_EARLY_PARAMS["log_cho_lge_lge_early_lo"],
-    log_cho_lge_lge_early_hi=LOG_CHO_LGE_LGE_EARLY_PARAMS["log_cho_lge_lge_early_hi"],
+    log_cho_lge_lge_early_lo=COV_PARAMS_EARLY["log_cho_lge_lge_early_lo"],
+    log_cho_lge_lge_early_hi=COV_PARAMS_EARLY["log_cho_lge_lge_early_hi"],
 ):
     return _sigmoid(lgm, 13, 0.5, log_cho_lge_lge_early_lo, log_cho_lge_lge_early_hi)
 
@@ -340,8 +331,8 @@ def _sigmoid(x, x0, k, ymin, ymax):
 @jjit
 def _lge_vs_lgm_late(
     lgm,
-    lge_late_lo=LGE_LATE_PARAMS["lge_late_lo"],
-    lge_late_hi=LGE_LATE_PARAMS["lge_late_hi"],
+    lge_late_lo=MEAN_PARAMS_LATE["lge_late_lo"],
+    lge_late_hi=MEAN_PARAMS_LATE["lge_late_hi"],
 ):
     return _sigmoid(lgm, 13, 0.5, lge_late_lo, lge_late_hi)
 
@@ -349,8 +340,8 @@ def _lge_vs_lgm_late(
 @jjit
 def _lge_vs_lgm_early(
     lgm,
-    lge_early_lo=LGE_EARLY_PARAMS["lge_early_lo"],
-    lge_early_hi=LGE_EARLY_PARAMS["lge_early_hi"],
+    lge_early_lo=MEAN_PARAMS_EARLY["lge_early_lo"],
+    lge_early_hi=MEAN_PARAMS_EARLY["lge_early_hi"],
 ):
     return _sigmoid(lgm, 13, 0.5, lge_early_lo, lge_early_hi)
 
@@ -358,8 +349,8 @@ def _lge_vs_lgm_early(
 @jjit
 def _lgl_vs_lgm_late(
     lgm,
-    lgl_late_lo=LGL_LATE_PARAMS["lgl_late_lo"],
-    lgl_late_hi=LGL_LATE_PARAMS["lgl_late_hi"],
+    lgl_late_lo=MEAN_PARAMS_LATE["lgl_late_lo"],
+    lgl_late_hi=MEAN_PARAMS_LATE["lgl_late_hi"],
 ):
     return _sigmoid(lgm, 13, 0.5, lgl_late_lo, lgl_late_hi)
 
@@ -367,8 +358,8 @@ def _lgl_vs_lgm_late(
 @jjit
 def _lgl_vs_lgm_early(
     lgm,
-    lgl_early_lo=LGL_EARLY_PARAMS["lgl_early_lo"],
-    lgl_early_hi=LGL_EARLY_PARAMS["lgl_early_hi"],
+    lgl_early_lo=MEAN_PARAMS_EARLY["lgl_early_lo"],
+    lgl_early_hi=MEAN_PARAMS_EARLY["lgl_early_hi"],
 ):
     return _sigmoid(lgm, 12.5, 1.5, lgl_early_lo, lgl_early_hi)
 
@@ -376,17 +367,19 @@ def _lgl_vs_lgm_early(
 @jjit
 def _x0_vs_lgm_late(
     lgm,
-    x0_late=X0_LATE_PARAMS["x0_late"],
+    x0_late_lo=MEAN_PARAMS_LATE["x0_late_lo"],
+    x0_late_hi=MEAN_PARAMS_LATE["x0_late_hi"],
 ):
-    return jnp.zeros_like(lgm) + x0_late
+    return _sigmoid(lgm, 13, 0.5, x0_late_lo, x0_late_hi)
 
 
 @jjit
 def _x0_vs_lgm_early(
     lgm,
-    x0_early=X0_EARLY_PARAMS["x0_early"],
+    x0_early_lo=MEAN_PARAMS_EARLY["x0_early_lo"],
+    x0_early_hi=MEAN_PARAMS_EARLY["x0_early_hi"],
 ):
-    return jnp.zeros_like(lgm) + x0_early
+    return _sigmoid(lgm, 13, 0.5, x0_early_lo, x0_early_hi)
 
 
 @jjit
@@ -395,19 +388,20 @@ def _mah_pdf_early(
     lge,
     lgl,
     x0,
-    lge_early_lo=LGE_EARLY_PARAMS["lge_early_lo"],
-    lge_early_hi=LGE_EARLY_PARAMS["lge_early_hi"],
-    lgl_early_lo=LGL_EARLY_PARAMS["lgl_early_lo"],
-    lgl_early_hi=LGL_EARLY_PARAMS["lgl_early_hi"],
-    x0_early=X0_EARLY_PARAMS["x0_early"],
-    log_cho_lge_lge_early_lo=LOG_CHO_LGE_LGE_EARLY_PARAMS["log_cho_lge_lge_early_lo"],
-    log_cho_lge_lge_early_hi=LOG_CHO_LGE_LGE_EARLY_PARAMS["log_cho_lge_lge_early_hi"],
-    log_cho_lgl_lgl_early_lo=LOG_CHO_LGL_LGL_EARLY_PARAMS["log_cho_lgl_lgl_early_lo"],
-    log_cho_lgl_lgl_early_hi=LOG_CHO_LGL_LGL_EARLY_PARAMS["log_cho_lgl_lgl_early_hi"],
-    log_cho_x0_x0_early=LOG_CHO_X0_X0_EARLY_PARAMS["log_cho_x0_x0_early"],
-    cho_lge_lgl_early=CHO_LGE_LGL_EARLY_PARAMS["cho_lge_lgl_early"],
-    cho_lge_x0_early=CHO_LGE_X0_EARLY_PARAMS["cho_lge_x0_early"],
-    cho_lgl_x0_early=CHO_LGL_X0_EARLY_PARAMS["cho_lgl_x0_early"],
+    lge_early_lo=MEAN_PARAMS_EARLY["lge_early_lo"],
+    lge_early_hi=MEAN_PARAMS_EARLY["lge_early_hi"],
+    lgl_early_lo=MEAN_PARAMS_EARLY["lgl_early_lo"],
+    lgl_early_hi=MEAN_PARAMS_EARLY["lgl_early_hi"],
+    x0_early_lo=MEAN_PARAMS_EARLY["x0_early_lo"],
+    x0_early_hi=MEAN_PARAMS_EARLY["x0_early_hi"],
+    log_cho_lge_lge_early_lo=COV_PARAMS_EARLY["log_cho_lge_lge_early_lo"],
+    log_cho_lge_lge_early_hi=COV_PARAMS_EARLY["log_cho_lge_lge_early_hi"],
+    log_cho_lgl_lgl_early_lo=COV_PARAMS_EARLY["log_cho_lgl_lgl_early_lo"],
+    log_cho_lgl_lgl_early_hi=COV_PARAMS_EARLY["log_cho_lgl_lgl_early_hi"],
+    log_cho_x0_x0_early=COV_PARAMS_EARLY["log_cho_x0_x0_early"],
+    cho_lge_lgl_early=COV_PARAMS_EARLY["cho_lge_lgl_early"],
+    cho_lge_x0_early=COV_PARAMS_EARLY["cho_lge_x0_early"],
+    cho_lgl_x0_early=COV_PARAMS_EARLY["cho_lgl_x0_early"],
 ):
     X = jnp.array((lge, lgl, x0)).astype("f4").T
     mu = _get_mean_mah_params_early(
@@ -416,7 +410,8 @@ def _mah_pdf_early(
         lge_early_hi,
         lgl_early_lo,
         lgl_early_hi,
-        x0_early,
+        x0_early_lo,
+        x0_early_hi,
     )
     cov = _get_cov_early(
         lgm,
@@ -438,19 +433,20 @@ def _mah_pdf_late(
     lge,
     lgl,
     x0,
-    lge_late_lo=LGE_LATE_PARAMS["lge_late_lo"],
-    lge_late_hi=LGE_LATE_PARAMS["lge_late_hi"],
-    lgl_late_lo=LGL_LATE_PARAMS["lgl_late_lo"],
-    lgl_late_hi=LGL_LATE_PARAMS["lgl_late_hi"],
-    x0_late=X0_LATE_PARAMS["x0_late"],
-    log_cho_lge_lge_late_lo=LOG_CHO_LGE_LGE_LATE_PARAMS["log_cho_lge_lge_late_lo"],
-    log_cho_lge_lge_late_hi=LOG_CHO_LGE_LGE_LATE_PARAMS["log_cho_lge_lge_late_hi"],
-    log_cho_lgl_lgl_late_lo=LOG_CHO_LGL_LGL_LATE_PARAMS["log_cho_lgl_lgl_late_lo"],
-    log_cho_lgl_lgl_late_hi=LOG_CHO_LGL_LGL_LATE_PARAMS["log_cho_lgl_lgl_late_hi"],
-    log_cho_x0_x0_late=LOG_CHO_X0_X0_LATE_PARAMS["log_cho_x0_x0_late"],
-    cho_lge_lgl_late=CHO_LGE_LGL_LATE_PARAMS["cho_lge_lgl_late"],
-    cho_lge_x0_late=CHO_LGE_X0_LATE_PARAMS["cho_lge_x0_late"],
-    cho_lgl_x0_late=CHO_LGL_X0_LATE_PARAMS["cho_lgl_x0_late"],
+    lge_late_lo=MEAN_PARAMS_LATE["lge_late_lo"],
+    lge_late_hi=MEAN_PARAMS_LATE["lge_late_hi"],
+    lgl_late_lo=MEAN_PARAMS_LATE["lgl_late_lo"],
+    lgl_late_hi=MEAN_PARAMS_LATE["lgl_late_hi"],
+    x0_late_lo=MEAN_PARAMS_LATE["x0_late_lo"],
+    x0_late_hi=MEAN_PARAMS_LATE["x0_late_hi"],
+    log_cho_lge_lge_late_lo=COV_PARAMS_LATE["log_cho_lge_lge_late_lo"],
+    log_cho_lge_lge_late_hi=COV_PARAMS_LATE["log_cho_lge_lge_late_hi"],
+    log_cho_lgl_lgl_late_lo=COV_PARAMS_LATE["log_cho_lgl_lgl_late_lo"],
+    log_cho_lgl_lgl_late_hi=COV_PARAMS_LATE["log_cho_lgl_lgl_late_hi"],
+    log_cho_x0_x0_late=COV_PARAMS_LATE["log_cho_x0_x0_late"],
+    cho_lge_lgl_late=COV_PARAMS_LATE["cho_lge_lgl_late"],
+    cho_lge_x0_late=COV_PARAMS_LATE["cho_lge_x0_late"],
+    cho_lgl_x0_late=COV_PARAMS_LATE["cho_lgl_x0_late"],
 ):
     X = jnp.array((lge, lgl, x0)).astype("f4").T
     mu = _get_mean_mah_params_late(
@@ -459,7 +455,8 @@ def _mah_pdf_late(
         lge_late_hi,
         lgl_late_lo,
         lgl_late_hi,
-        x0_late,
+        x0_late_lo,
+        x0_late_hi,
     )
     cov = _get_cov_late(
         lgm,

--- a/diffmah/tests/test_halo_population_assembly.py
+++ b/diffmah/tests/test_halo_population_assembly.py
@@ -1,7 +1,7 @@
 """
 """
 import numpy as np
-from ..halo_population_assembly import _get_average_halo_histories
+from ..halo_population_assembly import _get_bimodal_halo_history
 
 
 def test_get_average_halo_histories():
@@ -16,8 +16,9 @@ def test_get_average_halo_histories():
     tarr = np.linspace(1, 13.8, 25)
     lgt_arr = np.log10(tarr)
     lgmp_arr = np.array((11.25, 11.75, 12, 12.5, 13, 13.5, 14, 14.5))
-    _res = _get_average_halo_histories(lgt_arr, lgmp_arr, lge_arr, lgl_arr, x0_arr)
-    mean_dmhdts, mean_log_mahs, std_dmhdt, std_log_mah = _res
+    _res = _get_bimodal_halo_history(lgt_arr, lgmp_arr, lge_arr, lgl_arr, x0_arr)
+    mean_dmhdt, mean_mah, variance_dmhdt, variance_mah = _res
+    mean_log_mahs = np.log10(mean_mah)
 
     #  Average halo MAHs should agree at t=today
     assert np.allclose(mean_log_mahs[:, -1], lgmp_arr, atol=0.01)
@@ -26,4 +27,4 @@ def test_get_average_halo_histories():
     assert np.all(np.diff(mean_log_mahs, axis=1) > 0)
 
     # Average halo accretion rates should monotonically increase with present-day mass
-    assert np.all(np.diff(mean_dmhdts[:, -1]) > 0)
+    assert np.all(np.diff(mean_dmhdt[:, -1]) > 0)


### PR DESCRIPTION
This PR updates the PDF model parameters. The new level of agreement is shown in this plot.

![pdf_model_validation](https://user-images.githubusercontent.com/6951595/114608694-9034b200-9c63-11eb-93de-408a59c39a86.png)

There is a noticeable discrepancy in the variance at early times and high mass. This discrepancy is actually real, but the above plot makes the level of agreement visually appear to be a lot worse than it actually is. To see why this happens, first have a look at this next plot which directly plots the target variance.

![cluster_mass_variance_test (1)](https://user-images.githubusercontent.com/6951595/114609031-f4577600-9c63-11eb-99e9-30196f7a916b.png)

So the agreement with the variance is actually quite good. However, in making the first plot, the lower curve is computed simply as the average MAH minus the variance, and for the best-fitting model, the variance is ever-so-slightly greater than the average MAH, so the plotted curve rapidly falls off since it's a log-log plot and the last point is negative.

The source of this discrepancy is that the best-fitting model predicts a tiny but non-vanishing tail at low halo mass at early times. This next plot focuses on present-day cluster-mass halos, and compares model to actual MAH PDFs across time for a few different snaps. The leftmost panel in the plot below shows the earliest redshift shown in the first multi-panel plot, and so zeros in on that last data point where the lower variance visually appears to fall way below the target.
![cluster_mass_distributions_highz](https://user-images.githubusercontent.com/6951595/114610770-e7d41d00-9c65-11eb-9621-b25cbc57b861.png)
Looking at the full PDFs shows that the level of agreement is really quite good. The target distribution is simply not very Gaussian, and so our use of the mean and variance as summary statistics of the target data is ultimately the root problem that prevents the level of agreement from being even better.

With these plots in mind, I'm not actually how much better we want to do than this. For example, one kind of game we could play is to use the _trimmed_ mean and variance as our target data, rather than the actual mean and variance. That would be less sensitive to what's going on in the tails, which we don't care so much about anyway. However, I don't have an easy way to make a differentiable prediction for the trimmed mean (remember that when making model predictions within this optimization exercise, I'm computing the PDF-weighted mean and variance "manually" using a rectangular grid of a few thousand points in the 3d space of log(early), log(late), x0).

I think for purposes of the diffmah paper, it's time to move on, to generate all the remaining figures for the publication, and to write a complete draft end to end. If people have bright ideas for simple ways to continue to improve upon this, that would be great of course, I mean it would certainly be really nice to have _all_ the curves hugging _all_ the target data at _all_ mass, with no visual disagreement at all. But for now, let's set this aside and move forward with writing the paper to completion. Then we can return to this nagging discrepancy and see if we can refine the fits with some cleverness.




