### PR TITLE
Finished penultimate calibration of MAH model

### DIFF
--- a/diffmah/halo_population_assembly.py
+++ b/diffmah/halo_population_assembly.py
@@ -68,19 +68,18 @@ def _get_bimodal_halo_history_kern(
     weights_late = weights_late.reshape((n_x0, n_late, n_early, 1))
 
     w = frac_late * weights_late + (1 - frac_late) * weights_early
-    w_mahs = mahs * w
-    w_dmhdts = dmhdts * w
 
-    mean_dmhdt = jnp.sum(w_dmhdts, axis=(0, 1, 2))
-    mean_mah = jnp.sum(w_mahs, axis=(0, 1, 2))
+    mean_dmhdt = jnp.sum(dmhdts * w, axis=(0, 1, 2))
+    mean_mah = jnp.sum(mahs * w, axis=(0, 1, 2))
+    mean_log_mah = jnp.sum(log_mahs * w, axis=(0, 1, 2))
 
     delta_dmhdt_sq = (dmhdts - mean_dmhdt) ** 2
-    delta_mah_sq = (mahs - mean_mah) ** 2
+    delta_log_mah_sq = (log_mahs - mean_log_mah) ** 2
 
     variance_dmhdt = jnp.sum(delta_dmhdt_sq * w, axis=(0, 1, 2))
-    variance_mah = jnp.sum(delta_mah_sq * w, axis=(0, 1, 2))
+    variance_log_mah = jnp.sum(delta_log_mah_sq * w, axis=(0, 1, 2))
 
-    return mean_dmhdt, mean_mah, variance_dmhdt, variance_mah
+    return mean_dmhdt, mean_mah, mean_log_mah, variance_dmhdt, variance_log_mah
 
 
 _a = (None, 0, None, None, None, *[0] * 5)

--- a/diffmah/mah_pop_param_model.py
+++ b/diffmah/mah_pop_param_model.py
@@ -7,41 +7,41 @@ from jax import vmap
 from jax.scipy.stats import multivariate_normal as jnorm
 
 FRAC_LATE_FORMING_PARAMS = OrderedDict(
-    frac_late_forming_lo=0.45, frac_late_forming_hi=0.65
+    frac_late_forming_lo=0.53, frac_late_forming_hi=0.69
 )
 MEAN_PARAMS_EARLY = OrderedDict(
     lge_early_lo=0.48,
-    lge_early_hi=0.98,
-    lgl_early_lo=-0.60,
-    lgl_early_hi=0.22,
-    x0_early_lo=-0.30,
-    x0_early_hi=-0.21,
+    lge_early_hi=0.86,
+    lgl_early_lo=-0.53,
+    lgl_early_hi=0.18,
+    x0_early_lo=-0.24,
+    x0_early_hi=-0.28,
 )
 
 MEAN_PARAMS_LATE = OrderedDict(
-    lge_late_lo=-0.15,
-    lge_late_hi=0.76,
-    lgl_late_lo=-1.23,
-    lgl_late_hi=0.44,
-    x0_late_lo=0.42,
-    x0_late_hi=0.62,
+    lge_late_lo=-0.20,
+    lge_late_hi=0.73,
+    lgl_late_lo=-1.11,
+    lgl_late_hi=0.45,
+    x0_late_lo=0.53,
+    x0_late_hi=0.64,
 )
 COV_PARAMS_EARLY = OrderedDict(
-    log_cho_lge_lge_early_lo=-0.50,
-    log_cho_lge_lge_early_hi=-0.79,
-    log_cho_lgl_lgl_early_lo=-0.16,
-    log_cho_lgl_lgl_early_hi=-1.14,
-    log_cho_x0_x0_early=-0.97,
+    log_cho_lge_lge_early_lo=-0.33,
+    log_cho_lge_lge_early_hi=-1.07,
+    log_cho_lgl_lgl_early_lo=-0.11,
+    log_cho_lgl_lgl_early_hi=-1.30,
+    log_cho_x0_x0_early=-1.06,
     cho_lge_lgl_early=-0.05,
     cho_lge_x0_early=-0.05,
     cho_lgl_x0_early=-0.11,
 )
 COV_PARAMS_LATE = OrderedDict(
-    log_cho_lge_lge_late_lo=-0.51,
-    log_cho_lge_lge_late_hi=-1.34,
-    log_cho_lgl_lgl_late_lo=-0.35,
+    log_cho_lge_lge_late_lo=-0.49,
+    log_cho_lge_lge_late_hi=-1.47,
+    log_cho_lgl_lgl_late_lo=-0.65,
     log_cho_lgl_lgl_late_hi=-0.44,
-    log_cho_x0_x0_late=-0.80,
+    log_cho_x0_x0_late=-0.92,
     cho_lge_lgl_late=-0.02,
     cho_lge_x0_late=0.00,
     cho_lgl_x0_late=0.02,

--- a/diffmah/tests/test_halo_population_assembly.py
+++ b/diffmah/tests/test_halo_population_assembly.py
@@ -17,7 +17,7 @@ def test_get_average_halo_histories():
     lgt_arr = np.log10(tarr)
     lgmp_arr = np.array((11.25, 11.75, 12, 12.5, 13, 13.5, 14, 14.5))
     _res = _get_bimodal_halo_history(lgt_arr, lgmp_arr, lge_arr, lgl_arr, x0_arr)
-    mean_dmhdt, mean_mah, variance_dmhdt, variance_mah = _res
+    mean_dmhdt, mean_mah, mean_log_mah, variance_dmhdt, variance_mah = _res
     mean_log_mahs = np.log10(mean_mah)
 
     #  Average halo MAHs should agree at t=today


### PR DESCRIPTION
This PR improves upon the PDF model calibration previously merged in with #75. This new plot shows the performance of the new calibration.

![updated_pdf_model_validation](https://user-images.githubusercontent.com/6951595/114751921-60e17c00-9d1b-11eb-8bb5-95fc1d7f24c2.png)


There are two main differences that gave us these improvements:
1. We now optimize for the variance in log10(Mhalo), rather than in Mhalo. Doing things this way is less sensitive to the tails.
2. I lowered the highest target halo mass to 10^14.75, which has considerably better sampling and so is less subject to wild outliers throwing off the target prediction.

Thanks to @jchavesmontero for encouraging application of extra mustard.

When doing a fine-grained calibration like this, I find it's important to verify that the solution is not just some obscure degeneracy in the model parameter space. If the fitter is simply allowed to run wild, it will identify an even better solution that results in grossly discrepant distributions of the best-fit parameters. The recent PR #76 really simplifies this, because it makes it easy to visually examine how the distribution of best-fit parameters has changed. Since the original calibration was done by eye to agree with distributions in the simulation, then this painstaking effort has paid off, because now we can just visually check that the best-fit solution has not wandered too far off from the reality. 

This plot compares the distributions for early- and late-forming populations. Blue/purple show old/new calibration for late-forming populations; red/orange show old/new calibrations for early-forming populations. 

![mc_halo_params_old_new_logm12](https://user-images.githubusercontent.com/6951595/114751854-4b6c5200-9d1b-11eb-9a87-b75ebe3c5762.png)

![mc_halo_params_old_new_logm15](https://user-images.githubusercontent.com/6951595/114751869-4f986f80-9d1b-11eb-8887-5592492dceca.png)





