### PR TITLE
circleci yaml cleanup

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -48,17 +48,13 @@ jobs:
             conda install -y -q \
               numpy \
               numba \
-              emcee \
               flake8 \
               pytest \
               scipy \
-              tqdm \
               pyyaml \
               jax \
               jaxlib>=0.1.45 \
-              pytest-runner \
-              "halotools>=0.7" \
-              "astropy>=4"
+              pytest-runner
 
             pip install --no-deps -e .
 


### PR DESCRIPTION
Removed emcee tqdm halotools and astropy from circleci environment as there are not used anywhere in the package