### PR TITLE
Changed API of mc_halo_population to support array logmh argument

### DIFF
--- a/diffmah/monte_carlo_halo_population.py
+++ b/diffmah/monte_carlo_halo_population.py
@@ -37,8 +37,11 @@ def mc_halo_population(
         Default behavior is to generate a random mixture of the two populations
         with a fraction appropriate for the input mass.
 
+    ran_key : jax random seed, optional
+        If no random key is provided, jran.PRNGKey(seed) will be chosen every time
+
     seed : int, optional
-        Random number seed
+        Random number seed. Default is zero.
 
     **kwargs : floats
         All parameters of the MAH PDF model are accepted as keyword arguments.

--- a/diffmah/tests/test_mc_halos.py
+++ b/diffmah/tests/test_mc_halos.py
@@ -14,8 +14,8 @@ def test_mc_halo_assembly_returns_correctly_shaped_arrays():
     n_halos, n_times = 500, 50
     tarr = np.linspace(1, 13.8, n_times)
     t0 = tarr[-1]
-    logmh = 12.0
-    res = mc_halo_population(tarr, t0, logmh, n_halos)
+    logmh = 12.0 + np.zeros(n_halos)
+    res = mc_halo_population(tarr, t0, logmh)
     dmhdt, log_mah, early, late, lgtc, mah_type = res
     assert dmhdt.shape == (n_halos, n_times)
     assert log_mah.shape == (n_halos, n_times)
@@ -25,8 +25,8 @@ def test_mc_halo_assembly_returns_correct_z0_masses():
     n_halos, n_times = 500, 100
     tarr = np.linspace(0.1, 13.8, n_times)
     t0 = tarr[-1]
-    logmh = 12.0
-    res = mc_halo_population(tarr, t0, logmh, n_halos)
+    logmh = 12.0 + np.zeros(n_halos)
+    res = mc_halo_population(tarr, t0, logmh)
     dmhdt, log_mah, early, late, lgtc, mah_type = res
     assert np.allclose(log_mah[:, -1], logmh)
 
@@ -36,7 +36,7 @@ def test_mc_halo_assembly_returns_monotonic_halo_histories():
     tarr = np.linspace(0.1, 13.8, n_times)
     t0 = tarr[-1]
     for logmh in (10, 12, 14, 16):
-        res = mc_halo_population(tarr, t0, logmh, n_halos)
+        res = mc_halo_population(tarr, t0, logmh + np.zeros(n_halos))
         dmhdt, log_mah, early, late, lgtc, mah_type = res
 
         msg = "Some MC generated halos have non-increasing masses across time"
@@ -54,7 +54,7 @@ def test_mc_halo_assembly_returns_mix_of_halo_types():
     tarr = np.linspace(0.1, 13.8, n_times)
     t0 = tarr[-1]
     for logmh in (10, 12, 14, 16):
-        res = mc_halo_population(tarr, t0, logmh, n_halos)
+        res = mc_halo_population(tarr, t0, logmh + np.zeros(n_halos))
         dmhdt, log_mah, early, late, lgtc, mah_type = res
         assert np.any(mah_type == "early")
         assert np.any(mah_type == "late")
@@ -65,10 +65,10 @@ def test_mah_type_argument_of_mc_halo_assembly():
     tarr = np.linspace(0.1, 13.8, n_times)
     t0 = tarr[-1]
     for logmh in (10, 12, 14, 16):
-        res0 = mc_halo_population(tarr, t0, logmh, n_halos, mah_type="early")
+        res0 = mc_halo_population(tarr, t0, logmh + np.zeros(n_halos), mah_type="early")
         dmhdt0, log_mah0, early0, late0, lgtc0, mah_type0 = res0
         assert np.all(mah_type0 == "early")
-        res1 = mc_halo_population(tarr, t0, logmh, n_halos, mah_type="late")
+        res1 = mc_halo_population(tarr, t0, logmh + np.zeros(n_halos), mah_type="late")
         dmhdt1, log_mah1, early1, late1, lgtc1, mah_type1 = res1
         assert np.all(mah_type1 == "late")
         assert lgtc0.mean() < lgtc1.mean()
@@ -80,14 +80,14 @@ def test_mc_halo_assembly_early_late_options():
     t0 = tarr[-1]
 
     for logmh in (11, 13, 15):
-        res = mc_halo_population(tarr, t0, logmh, n_halos, mah_type="early")
+        res = mc_halo_population(tarr, t0, logmh + np.zeros(n_halos), mah_type="early")
         dmhdt_early, log_mah_early, early_early, late_early, lgtc_early, mah_type = res
         assert dmhdt_early.shape == (n_halos, n_times)
         assert log_mah_early.shape == (n_halos, n_times)
         assert np.allclose(log_mah_early[:, -1], logmh)
         assert np.all(mah_type == "early")
 
-        res = mc_halo_population(tarr, t0, logmh, n_halos, mah_type="late")
+        res = mc_halo_population(tarr, t0, logmh + np.zeros(n_halos), mah_type="late")
         dmhdt_late, log_mah_late, early_late, late_late, lgtc_late, mah_type = res
         assert dmhdt_late.shape == (n_halos, n_times)
         assert log_mah_late.shape == (n_halos, n_times)
@@ -96,7 +96,7 @@ def test_mc_halo_assembly_early_late_options():
 
         assert np.mean(lgtc_early) < np.mean(lgtc_late)
 
-        res = mc_halo_population(tarr, t0, logmh, n_halos)
+        res = mc_halo_population(tarr, t0, logmh + np.zeros(n_halos))
         dmhdt, log_mah, early, late, lgtc, mah_type = res
 
         mean_dmhdt_early = np.mean(dmhdt_early, axis=0)
@@ -130,7 +130,7 @@ def test_mc_realization_agrees_with_tabulated_nbody_simulation_data():
     for im, lgmp in enumerate(lgmp_targets):
         mean_log_mah_correct = mean_log_mah_targets[im]
         mean_dmhdt_correct = mean_dmhdt_targets[im]
-        pop = mc_halo_population(t, t[-1], lgmp, n_halos)
+        pop = mc_halo_population(t, t[-1], lgmp + np.zeros(n_halos))
         dmhdt, log_mah = pop[:2]
         mean_log_mah_mc = np.mean(log_mah, axis=0)
         mean_dmhdt_mc = np.mean(dmhdt, axis=0)
@@ -154,7 +154,7 @@ def test_mc_realization_agrees_with_tabulated_tng_simulation_data():
     for im, lgmp in enumerate(lgmp_targets):
         mean_log_mah_correct = mean_log_mah_targets[im]
         mean_dmhdt_correct = mean_dmhdt_targets[im]
-        pop = mc_halo_population(t, t[-1], lgmp, n_halos, **TNG_PDF_PARAMS)
+        pop = mc_halo_population(t, t[-1], lgmp + np.zeros(n_halos), **TNG_PDF_PARAMS)
         dmhdt, log_mah = pop[:2]
         mean_log_mah_mc = np.mean(log_mah, axis=0)
         mean_dmhdt_mc = np.mean(dmhdt, axis=0)


### PR DESCRIPTION
Previously, the Monte Carlo generator of `diffmah` halo histories only accepted a float argument for the final halo mass. With this PR, an array of different halo masses is now accepted.