### PR TITLE
Namedtuple syntax for MC halo pop

### DIFF
--- a/diffmah/monte_carlo_halo_population.py
+++ b/diffmah/monte_carlo_halo_population.py
@@ -1,11 +1,25 @@
 """
 """
+from collections import namedtuple
 import numpy as np
 from jax import numpy as jnp
 from jax import random as jran
 from .rockstar_pdf_model import _get_mah_means_and_covs
 from .individual_halo_assembly import calc_halo_history, _get_early_late
 from .individual_halo_assembly import DEFAULT_MAH_PARAMS
+
+
+_MCHaloPop = namedtuple(
+    "MCHaloPop",
+    [
+        "dmhdt",
+        "log_mah",
+        "early_index",
+        "late_index",
+        "lgtc",
+        "mah_type",
+    ],
+)
 
 
 def mc_halo_population(
@@ -112,4 +126,4 @@ def mc_halo_population(
     early, late = _get_early_late(mah_ue, mah_ul)
     _res = calc_halo_history(10 ** lgt, 10 ** lgt0, logmh, 10 ** mah_lgtc, early, late)
     dmhdt, log_mah = _res
-    return dmhdt, log_mah, early, late, mah_lgtc, mah_type_arr
+    return _MCHaloPop(*(dmhdt, log_mah, early, late, mah_lgtc, mah_type_arr))

--- a/diffmah/tests/test_mc_halos.py
+++ b/diffmah/tests/test_mc_halos.py
@@ -10,6 +10,20 @@ _THIS_DRNAME = os.path.dirname(os.path.abspath(__file__))
 DDRN = os.path.join(_THIS_DRNAME, "testing_data")
 
 
+def test_mc_halo_assembly_namedtuple_syntax():
+    n_halos, n_times = 500, 50
+    tarr = np.linspace(1, 13.8, n_times)
+    t0 = tarr[-1]
+    logmh = 12.0 + np.zeros(n_halos)
+    mc_halopop = mc_halo_population(tarr, t0, logmh)
+    assert mc_halopop.dmhdt.shape == (n_halos, n_times)
+    assert mc_halopop.log_mah.shape == (n_halos, n_times)
+    assert mc_halopop.early_index.shape == (n_halos,)
+    assert mc_halopop.late_index.shape == (n_halos,)
+    assert mc_halopop.lgtc.shape == (n_halos,)
+    assert mc_halopop.mah_type.shape == (n_halos,)
+
+
 def test_mc_halo_assembly_returns_correctly_shaped_arrays():
     n_halos, n_times = 500, 50
     tarr = np.linspace(1, 13.8, n_times)


### PR DESCRIPTION
This PR adopts a backwards-compatible change to the return value of the **mc_halo_population** function. Previously, **mc_halo_population** returned a tuple; now it returns a namedtuple.