### PR TITLE
Fix bug in Monte Carlo generator of MAHs for halos identified at high redshift

### DIFF
--- a/diffmah/monte_carlo_diffmah_hiz.py
+++ b/diffmah/monte_carlo_diffmah_hiz.py
@@ -88,9 +88,14 @@ def _guess_logmp_z0(t_obs, logmh, lgt0, npop):
 
     logmp_hiz_table = np.linspace(logmh.min() - 0.1, logmh.max() + 0.1, 50)
     dlgmp = np.diff(logmp_hiz_table)[0]
-    logmp_z0_table = [
-        np.median(log_mah[:, 1][np.abs(log_mah[:, 0] - lgm) < dlgmp])
-        for lgm in logmp_hiz_table
-    ]
-    logmp_z0 = np.interp(logmh, logmp_hiz_table, logmp_z0_table)
+
+    masks = [np.abs(log_mah[:, 0] - lgm) < dlgmp for lgm in logmp_hiz_table]
+    ns = [msk.sum() for msk in masks]
+    logmp_hiz_table_filtered = [lgm for n, lgm in zip(ns, logmp_hiz_table) if n > 0]
+    masks_filtered = [msk for n, msk in zip(ns, masks) if n > 0]
+
+    logmp_z0_table = [np.median(log_mah[:, 1][msk]) for msk in masks_filtered]
+
+    logmp_z0 = np.interp(logmh, logmp_hiz_table_filtered, logmp_z0_table)
+
     return logmp_z0

--- a/diffmah/tests/test_monte_carlo_diffmah_hiz.py
+++ b/diffmah/tests/test_monte_carlo_diffmah_hiz.py
@@ -47,7 +47,9 @@ def test_mc_diffmah_params_all_halos_with_same_mass():
 
 def test_mc_diffmah_params_empty_slice_regression_test():
     """Enforce that we do not compute the median of an empty slice for a halo sample
-    with high-z masses that are more coarsely spaced than our interpolation table
+    with high-z masses that are more coarsely spaced than our interpolation table.
+    This is a regression test for a bug fixed with Pull Request
+    https://github.com/ArgonneCPAC/diffmah/pull/99
     """
     t_obs = 13.4
     t0 = 13.8

--- a/diffmah/tests/test_monte_carlo_diffmah_hiz.py
+++ b/diffmah/tests/test_monte_carlo_diffmah_hiz.py
@@ -1,5 +1,6 @@
 """
 """
+import warnings
 from jax import random as jran
 import numpy as np
 from ..individual_halo_assembly import calc_halo_history
@@ -15,7 +16,10 @@ def test_mc_diffmah_params():
     lgt0 = np.log10(t0)
     logmh = np.linspace(8, 15, 1000)
     ran_key = jran.PRNGKey(0)
-    lgm0, lgtc, early, late = mc_diffmah_params_hiz(ran_key, t_obs, logmh, lgt0=lgt0)
+    with warnings.catch_warnings(record=True) as w:
+        res = mc_diffmah_params_hiz(ran_key, t_obs, logmh, lgt0=lgt0)
+        assert len(w) == 0, "mc_diffmah_params_hiz raises warning"
+    lgm0, lgtc, early, late = res
     tc = 10**lgtc
     tarr = np.array((t_obs, t0))
     log_mah = calc_halo_history(tarr, t0, lgm0, tc, early, late)[1]
@@ -31,7 +35,29 @@ def test_mc_diffmah_params_all_halos_with_same_mass():
     lgt0 = np.log10(t0)
     logmh = np.zeros(1000) + 12
     ran_key = jran.PRNGKey(0)
-    lgm0, lgtc, early, late = mc_diffmah_params_hiz(ran_key, t_obs, logmh, lgt0=lgt0)
+    with warnings.catch_warnings(record=True) as w:
+        res = mc_diffmah_params_hiz(ran_key, t_obs, logmh, lgt0=lgt0)
+        assert len(w) == 0, "mc_diffmah_params_hiz raises warning"
+    lgm0, lgtc, early, late = res
+    tc = 10**lgtc
+    tarr = np.array((t_obs, t0))
+    log_mah = calc_halo_history(tarr, t0, lgm0, tc, early, late)[1]
+    assert np.allclose(log_mah[:, 0], logmh, atol=1e-4)
+
+
+def test_mc_diffmah_params_empty_slice_regression_test():
+    """Enforce that we do not compute the median of an empty slice for a halo sample
+    with high-z masses that are more coarsely spaced than our interpolation table
+    """
+    t_obs = 13.4
+    t0 = 13.8
+    lgt0 = np.log10(t0)
+    logmh = np.array((10.84, 11.2))
+    ran_key = jran.PRNGKey(0)
+    with warnings.catch_warnings(record=True) as w:
+        res = mc_diffmah_params_hiz(ran_key, t_obs, logmh, lgt0=lgt0)
+        assert len(w) == 0, "mc_diffmah_params_hiz raises warning"
+    lgm0, lgtc, early, late = res
     tc = 10**lgtc
     tarr = np.array((t_obs, t0))
     log_mah = calc_halo_history(tarr, t0, lgm0, tc, early, late)[1]


### PR DESCRIPTION
This PR resolves a bug caught by @evevkovacs in the `_guess_logmp_z0` function that helps generate Diffmah parameters of halos that are identified at high redshift without a surviving low-redshift counterpart. A new regression test `test_mc_diffmah_params_empty_slice_regression_test` is included in the PR, which fails without the fix, and passes with the fix.