### PR TITLE
Add convenience function to compute Cholesky matrix from parameter array

### DIFF
--- a/diffmah/rockstar_pdf_model.py
+++ b/diffmah/rockstar_pdf_model.py
@@ -1,9 +1,12 @@
 """Model of halo population assembly calibrated to Rockstar halos."""
 from collections import OrderedDict
+
 from jax import jit as jjit
 from jax import numpy as jnp
 from jax import vmap
+
 from .individual_halo_assembly import DEFAULT_MAH_PARAMS
+from .utils import get_cholesky_from_params
 
 TODAY = 13.8
 LGT0 = jnp.log10(TODAY)
@@ -67,13 +70,9 @@ def _get_cov_scalar(
     lge_lgtc,
     lgl_lgtc,
 ):
-    cho = jnp.zeros((3, 3)).astype("f4")
-    cho = cho.at[(0, 0)].set(10 ** log10_lge_lge)
-    cho = cho.at[(1, 1)].set(10 ** log10_lgl_lgl)
-    cho = cho.at[(2, 2)].set(10 ** log10_lgtc_lgtc)
-    cho = cho.at[(1, 0)].set(lge_lgl)
-    cho = cho.at[(2, 0)].set(lge_lgtc)
-    cho = cho.at[(2, 1)].set(lgl_lgtc)
+    diags = 10**log10_lge_lge, 10**log10_lgl_lgl, 10**log10_lgtc_lgtc
+    params = jnp.array((*diags, lge_lgl, lge_lgtc, lgl_lgtc))
+    cho = get_cholesky_from_params(params)
     cov = jnp.dot(cho, cho.T)
     return cov
 

--- a/diffmah/tests/test_utils.py
+++ b/diffmah/tests/test_utils.py
@@ -1,10 +1,16 @@
 """
 """
 import numpy as np
-from jax import numpy as jax_np
 from jax import jit as jax_jit
+from jax import numpy as jax_np
 from jax import value_and_grad
-from ..utils import jax_inverse_sigmoid, jax_sigmoid, jax_adam_wrapper
+
+from ..utils import (
+    get_cholesky_from_params,
+    jax_adam_wrapper,
+    jax_inverse_sigmoid,
+    jax_sigmoid,
+)
 
 
 def test_inverse_sigmoid_actually_inverts():
@@ -80,3 +86,35 @@ def test_jax_adam_wrapper_loss_tol_feature_works():
     assert loss_bestfit1 <= 1e-3
     assert loss_bestfit2 <= 1e-4
     assert loss_bestfit2 < loss_bestfit1 < loss_bestfit0 < loss_init
+
+
+def test_get_cholesky_from_params1():
+    ndim = 2
+    nparams = int(0.5 * ndim * (ndim + 1))
+    params = np.random.uniform(0, 1, nparams)
+    chol = get_cholesky_from_params(params)
+    row0 = (params[0], 0)
+    row1 = (params[2], params[1])
+    correct_chol = np.array((row0, row1))
+    assert np.allclose(chol, correct_chol)
+
+    ndim = 3
+    nparams = int(0.5 * ndim * (ndim + 1))
+    params = np.random.uniform(0, 1, nparams)
+    chol = get_cholesky_from_params(params)
+    row0 = (params[0], 0, 0)
+    row1 = (params[3], params[1], 0)
+    row2 = (params[4], params[5], params[2])
+    correct_chol = np.array((row0, row1, row2))
+    assert np.allclose(chol, correct_chol)
+
+    ndim = 4
+    nparams = int(0.5 * ndim * (ndim + 1))
+    params = np.random.uniform(0, 1, nparams)
+    chol = get_cholesky_from_params(params)
+    row0 = (params[0], 0, 0, 0)
+    row1 = (params[4], params[1], 0, 0)
+    row2 = (params[5], params[6], params[2], 0)
+    row3 = (params[7], params[8], params[9], params[3])
+    correct_chol = np.array((row0, row1, row2, row3))
+    assert np.allclose(chol, correct_chol)

--- a/diffmah/tng_pdf_model.py
+++ b/diffmah/tng_pdf_model.py
@@ -1,10 +1,13 @@
 """
 """
 from collections import OrderedDict
+
 from jax import jit as jjit
 from jax import numpy as jnp
 from jax import vmap
+
 from .individual_halo_assembly import DEFAULT_MAH_PARAMS
+from .utils import get_cholesky_from_params
 
 TODAY = 13.8
 LGT0 = jnp.log10(TODAY)
@@ -68,13 +71,9 @@ def _get_cov_scalar(
     lge_lgtc,
     lgl_lgtc,
 ):
-    cho = jnp.zeros((3, 3)).astype("f4")
-    cho = cho.at[(0, 0)].set(10 ** log10_lge_lge)
-    cho = cho.at[(1, 1)].set(10 ** log10_lgl_lgl)
-    cho = cho.at[(2, 2)].set(10 ** log10_lgtc_lgtc)
-    cho = cho.at[(1, 0)].set(lge_lgl)
-    cho = cho.at[(2, 0)].set(lge_lgtc)
-    cho = cho.at[(2, 1)].set(lgl_lgtc)
+    diags = 10**log10_lge_lge, 10**log10_lgl_lgl, 10**log10_lgtc_lgtc
+    params = jnp.array((*diags, lge_lgl, lge_lgtc, lgl_lgtc))
+    cho = get_cholesky_from_params(params)
     cov = jnp.dot(cho, cho.T)
     return cov
 


### PR DESCRIPTION
Previously, the computation of a covariance matrix from an array of parameters was done with a hard-coded assumption that the dimension of the covariance matrix is shape (3, 3). The new function `get_cholesky_from_params` programmatically computes the cholesky matrix defined by a parameter array of arbitrary dimension, adopting the same convention for the index correspondence as in the previous hard-coded case. This PR makes no change to the diffmah API.