### PR TITLE
Replace jnp.exp --> lax.exp

### DIFF
--- a/diffmah/individual_halo_assembly.py
+++ b/diffmah/individual_halo_assembly.py
@@ -3,6 +3,7 @@ from collections import OrderedDict
 
 from jax import grad
 from jax import jit as jjit
+from jax import lax
 from jax import numpy as jnp
 from jax import vmap
 
@@ -102,13 +103,13 @@ def _calc_halo_history(logt, logt0, logmp, logtc, k, early, late):
 
 @jjit
 def _softplus(x):
-    return jnp.log(1 + jnp.exp(x))
+    return jnp.log(1 + lax.exp(x))
 
 
 @jjit
 def _sigmoid(x, logtc, k, ymin, ymax):
     height_diff = ymax - ymin
-    return ymin + height_diff / (1.0 + jnp.exp(-k * (x - logtc)))
+    return ymin + height_diff / (1.0 + lax.exp(-k * (x - logtc)))
 
 
 @jjit
@@ -133,7 +134,7 @@ def _power_law_index_vs_logt(logt, logtc, k, early, late):
 
 @jjit
 def _inverse_softplus(s):
-    return jnp.log(jnp.exp(s) - 1.0)
+    return jnp.log(lax.exp(s) - 1.0)
 
 
 _vmap_halo_history = jjit(vmap(_calc_halo_history, in_axes=(None, None, 0, 0, 0, 0, 0)))

--- a/diffmah/rockstar_pdf_model.py
+++ b/diffmah/rockstar_pdf_model.py
@@ -2,6 +2,7 @@
 from collections import OrderedDict
 
 from jax import jit as jjit
+from jax import lax
 from jax import numpy as jnp
 from jax import vmap
 
@@ -59,7 +60,7 @@ DEFAULT_MAH_PDF_PARAMS = OrderedDict(
 @jjit
 def _sigmoid(x, logtc, k, ymin, ymax):
     height_diff = ymax - ymin
-    return ymin + height_diff / (1.0 + jnp.exp(-k * (x - logtc)))
+    return ymin + height_diff / (1.0 + lax.exp(-k * (x - logtc)))
 
 
 def _get_cov_scalar(

--- a/diffmah/tng_pdf_model.py
+++ b/diffmah/tng_pdf_model.py
@@ -3,6 +3,7 @@
 from collections import OrderedDict
 
 from jax import jit as jjit
+from jax import lax
 from jax import numpy as jnp
 from jax import vmap
 
@@ -60,7 +61,7 @@ DEFAULT_MAH_PDF_PARAMS = OrderedDict(
 @jjit
 def _sigmoid(x, logtc, k, ymin, ymax):
     height_diff = ymax - ymin
-    return ymin + height_diff / (1.0 + jnp.exp(-k * (x - logtc)))
+    return ymin + height_diff / (1.0 + lax.exp(-k * (x - logtc)))
 
 
 def _get_cov_scalar(

--- a/diffmah/utils.py
+++ b/diffmah/utils.py
@@ -1,6 +1,7 @@
 """Utility functions used throughout the package."""
 import numpy as np
 from jax import jit as jjit
+from jax import lax
 from jax import numpy as jnp
 from jax.example_libraries import optimizers as jax_opt
 
@@ -44,7 +45,7 @@ def jax_sigmoid(x, x0, k, ylo, yhi):
     -------
     sigmoid : scalar or array-like, same shape as input
     """
-    return ylo + (yhi - ylo) / (1 + jnp.exp(-k * (x - x0)))
+    return ylo + (yhi - ylo) / (1 + lax.exp(-k * (x - x0)))
 
 
 def jax_inverse_sigmoid(y, x0, k, ylo, yhi):


### PR DESCRIPTION
This PR improves numerical robustness of the calls to the exponential function, resolving an issue leading to NaNs in gradients.