### PR TITLE
Add new defaults.py module

### DIFF
--- a/diffmah/defaults.py
+++ b/diffmah/defaults.py
@@ -1,0 +1,13 @@
+"""
+"""
+# flake8: noqa
+from collections import OrderedDict
+
+import numpy as np
+
+TODAY = 13.8
+LGT0 = np.log10(TODAY)
+
+
+DEFAULT_MAH_PDICT = OrderedDict(logmp=12.0, logtc=0.05, early_index=2.5, late_index=1.0)
+DEFAULT_MAH_PARAMS = np.array(list(DEFAULT_MAH_PDICT.values()))


### PR DESCRIPTION
New defaults.py module anticipates change to conventions for the diffmah parameters that will be brought in with a future release. The new defaults.py module is the same structure now used in diffstar library, and that will be adopted throughout the Diff+ ecosystem.