### PR TITLE
Eliminate inconsistent usage of DEFAULT_MAH_PARAMS

### DIFF
--- a/.github/workflows/linting.yml
+++ b/.github/workflows/linting.yml
@@ -1,0 +1,49 @@
+name: linting
+
+on:
+  push:
+    branches:
+      - main
+  pull_request: null
+
+jobs:
+  tests:
+    name: tests
+    runs-on: "ubuntu-latest"
+
+    steps:
+      - uses: actions/checkout@v2
+
+      - uses: conda-incubator/setup-miniconda@v2
+        with:
+          python-version: 3.9
+          channels: conda-forge,defaults
+          channel-priority: strict
+          show-channel-urls: true
+          miniforge-version: latest
+          miniforge-variant: Mambaforge
+
+      - name: configure conda and install code
+          # Test against latest releases of each code in the dependency chain
+        shell: bash -l {0}
+        run: |
+          conda config --set always_yes yes
+          mamba install --quiet \
+            --file=requirements.txt
+          python -m pip install --no-deps -e .
+          mamba install -y -q \
+            flake8 \
+            pytest \
+            pytest-xdist \
+            pytest-cov \
+            pip \
+            setuptools \
+            "setuptools_scm>=7,<8" \
+            python-build \
+            flake8-pyproject
+          python -m pip install --no-build-isolation --no-deps -e .
+
+      - name: lint
+        shell: bash -l {0}
+        run: |
+          flake8 diffmah

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,6 +1,10 @@
 name: tests
 
 on:
+  workflow_dispatch: null
+  schedule:
+    # Runs "every Monday & Thursday at 3:05am Central"
+    - cron: '5 8 * * 1,4'
   push:
     branches:
       - main

--- a/diffmah/__init__.py
+++ b/diffmah/__init__.py
@@ -3,6 +3,7 @@
 # flake8: noqa
 
 from ._version import __version__
-from .individual_halo_assembly import calc_halo_history
+from .defaults import DEFAULT_MAH_PARAMS, MAH_K, DiffmahParams
+from .individual_halo_assembly import calc_halo_history, mah_halopop, mah_singlehalo
 from .monte_carlo_diffmah_hiz import mc_diffmah_params_hiz
 from .monte_carlo_halo_population import mc_halo_population

--- a/diffmah/defaults.py
+++ b/diffmah/defaults.py
@@ -9,7 +9,9 @@ TODAY = 13.8
 LGT0 = np.log10(TODAY)
 
 
-DEFAULT_MAH_PDICT = OrderedDict(logmp=12.0, logtc=0.05, early_index=2.5, late_index=1.0)
+DEFAULT_MAH_PDICT = OrderedDict(
+    logmp=12.0, logtc=0.05, early_index=2.6137643, late_index=0.12692805
+)
 DiffmahParams = namedtuple("DiffmahParams", list(DEFAULT_MAH_PDICT.keys()))
 DEFAULT_MAH_PARAMS = DiffmahParams(*list(DEFAULT_MAH_PDICT.values()))
 

--- a/diffmah/defaults.py
+++ b/diffmah/defaults.py
@@ -12,3 +12,5 @@ LGT0 = np.log10(TODAY)
 DEFAULT_MAH_PDICT = OrderedDict(logmp=12.0, logtc=0.05, early_index=2.5, late_index=1.0)
 DiffmahParams = namedtuple("DiffmahParams", list(DEFAULT_MAH_PDICT.keys()))
 DEFAULT_MAH_PARAMS = DiffmahParams(*list(DEFAULT_MAH_PDICT.values()))
+
+MAH_K = 3.5

--- a/diffmah/halo_population_assembly.py
+++ b/diffmah/halo_population_assembly.py
@@ -5,11 +5,8 @@ from jax import numpy as jnp
 from jax import vmap
 from jax.scipy.stats import multivariate_normal as jnorm
 
-from .individual_halo_assembly import (
-    DEFAULT_MAH_PARAMS,
-    _calc_halo_history,
-    _get_early_late,
-)
+from .defaults import MAH_K
+from .individual_halo_assembly import _calc_halo_history, _get_early_late
 from .rockstar_pdf_model import DEFAULT_MAH_PDF_PARAMS, LGT0, _get_mah_means_and_covs
 
 CLIP = -10.0
@@ -51,7 +48,7 @@ def _get_bimodal_halo_history_kern(
     mu_late,
     cov_early,
     cov_late,
-    k=DEFAULT_MAH_PARAMS["mah_k"],
+    k=MAH_K,
     logtmp=LGT0,
 ):
     early_arr, late_arr = _get_early_late(ue_arr, ul_arr)
@@ -133,7 +130,7 @@ def _get_bimodal_halo_history(
     chol_ue_lgtc_late_yhi=DEFAULT_MAH_PDF_PARAMS["chol_ue_lgtc_late_yhi"],
     chol_ul_lgtc_late_ylo=DEFAULT_MAH_PDF_PARAMS["chol_ul_lgtc_late_ylo"],
     chol_ul_lgtc_late_yhi=DEFAULT_MAH_PDF_PARAMS["chol_ul_lgtc_late_yhi"],
-    k=DEFAULT_MAH_PARAMS["mah_k"],
+    k=MAH_K,
     logtmp=LGT0,
 ):
     _res = _get_mah_means_and_covs(

--- a/diffmah/monte_carlo_halo_population.py
+++ b/diffmah/monte_carlo_halo_population.py
@@ -8,14 +8,9 @@ from jax import numpy as jnp
 from jax import random as jran
 from jax import vmap
 
-from .individual_halo_assembly import (
-    DEFAULT_MAH_PARAMS,
-    _calc_halo_history,
-    _get_early_late,
-)
+from .defaults import MAH_K
+from .individual_halo_assembly import _calc_halo_history, _get_early_late
 from .rockstar_pdf_model import DEFAULT_MAH_PDF_PARAMS, _get_mah_means_and_covs
-
-MAH_K = DEFAULT_MAH_PARAMS["mah_k"]
 
 _A = (None, None, 0, 0, None, 0, 0)
 _calc_halo_history_vmap = jjit(vmap(_calc_halo_history, in_axes=_A))

--- a/diffmah/rockstar_pdf_model.py
+++ b/diffmah/rockstar_pdf_model.py
@@ -6,12 +6,11 @@ from jax import lax
 from jax import numpy as jnp
 from jax import vmap
 
-from .individual_halo_assembly import DEFAULT_MAH_PARAMS
+from .defaults import MAH_K
 from .utils import get_cholesky_from_params
 
 TODAY = 13.8
 LGT0 = jnp.log10(TODAY)
-K = DEFAULT_MAH_PARAMS["mah_k"]
 
 _LGM_X0, LGM_K = 13.0, 0.5
 
@@ -352,7 +351,7 @@ def _get_mah_means_and_covs(
     chol_ue_lgtc_late_yhi=DEFAULT_MAH_PDF_PARAMS["chol_ue_lgtc_late_yhi"],
     chol_ul_lgtc_late_ylo=DEFAULT_MAH_PDF_PARAMS["chol_ul_lgtc_late_ylo"],
     chol_ul_lgtc_late_yhi=DEFAULT_MAH_PDF_PARAMS["chol_ul_lgtc_late_yhi"],
-    k=DEFAULT_MAH_PARAMS["mah_k"],
+    k=MAH_K,
     logtmp=LGT0,
 ):
     frac_late = frac_late_forming(logmp_arr, frac_late_ylo, frac_late_yhi)

--- a/diffmah/tests/test_defaults.py
+++ b/diffmah/tests/test_defaults.py
@@ -1,0 +1,26 @@
+"""
+"""
+import numpy as np
+
+
+def test_default_mah_params_imports_from_top_level_and_is_frozen():
+    from .. import DEFAULT_MAH_PARAMS
+
+    assert np.allclose(DEFAULT_MAH_PARAMS, (12.0, 0.05, 2.6137643, 0.12692805))
+
+
+def test_mah_k_imports_from_top_level():
+    from .. import MAH_K
+
+    assert np.allclose(MAH_K, 3.5)
+
+
+def test_mah_halopop_imports_from_top_level():
+    from .. import DEFAULT_MAH_PARAMS, DiffmahParams, mah_halopop
+
+    tarr = np.linspace(0.1, 13.7, 100)
+    ngals = 150
+    zz = np.zeros(ngals)
+    mah_params_halopop = DiffmahParams(*[x + zz for x in DEFAULT_MAH_PARAMS])
+    dmhdt, log_mah = mah_halopop(mah_params_halopop, tarr)
+    assert log_mah.shape == dmhdt.shape

--- a/diffmah/tests/test_individual_halo_assembly.py
+++ b/diffmah/tests/test_individual_halo_assembly.py
@@ -5,8 +5,8 @@ import os
 import numpy as np
 from jax import numpy as jnp
 
+from ..defaults import DEFAULT_MAH_PARAMS, MAH_K
 from ..individual_halo_assembly import (
-    DEFAULT_MAH_PARAMS,
     _calc_halo_history,
     _calc_halo_history_scalar,
     _get_early_late,
@@ -22,16 +22,15 @@ def test_calc_halo_history_evaluates():
     tarr = np.linspace(0.1, 14, 500)
     logt = np.log10(tarr)
     logtmp = logt[-1]
-    logmp = 12.0
-    lgtc, k, ue, ul = list(DEFAULT_MAH_PARAMS.values())
-    early, late = _get_early_late(ue, ul)
-    dmhdt, log_mah = _calc_halo_history(logt, logtmp, logmp, lgtc, k, early, late)
+    lgmp, lgtc, early, late = DEFAULT_MAH_PARAMS
+    dmhdt, log_mah = _calc_halo_history(logt, logtmp, lgmp, lgtc, MAH_K, early, late)
+    assert np.all(np.isfinite(dmhdt))
+    assert np.all(np.isfinite(log_mah))
 
 
 def test_rolling_index_agrees_with_hard_coded_expectation():
     lgmp_test = 12.5
 
-    k = DEFAULT_MAH_PARAMS["mah_k"]
     logt_bn = "logt_testing_array.dat"
     logt = np.loadtxt(os.path.join(DDRN, logt_bn))
     logt0 = logt[-1]
@@ -44,19 +43,19 @@ def test_rolling_index_agrees_with_hard_coded_expectation():
 
     indx_e_bn = "rolling_plaw_index_vs_time_rockstar_default_logmp_{0:.1f}_early.dat"
     index_early_correct = np.loadtxt(os.path.join(DDRN, indx_e_bn.format(lgmp_test)))
-    index_early = _power_law_index_vs_logt(logt, lgtc_e, k, early_e, late_e)
+    index_early = _power_law_index_vs_logt(logt, lgtc_e, MAH_K, early_e, late_e)
     assert np.allclose(index_early_correct, index_early, rtol=0.01)
 
     indx_l_bn = "rolling_plaw_index_vs_time_rockstar_default_logmp_{0:.1f}_late.dat"
     index_late_correct = np.loadtxt(os.path.join(DDRN, indx_l_bn.format(lgmp_test)))
-    index_late = _power_law_index_vs_logt(logt, lgtc_l, k, early_l, late_l)
+    index_late = _power_law_index_vs_logt(logt, lgtc_l, MAH_K, early_l, late_l)
     assert np.allclose(index_late_correct, index_late, rtol=0.01)
 
     dmhdt_e, log_mah_e = _calc_halo_history(
-        logt, logt0, lgmp_test, lgtc_e, k, early_e, late_e
+        logt, logt0, lgmp_test, lgtc_e, MAH_K, early_e, late_e
     )
     dmhdt_l, log_mah_l = _calc_halo_history(
-        logt, logt0, lgmp_test, lgtc_l, k, early_l, late_l
+        logt, logt0, lgmp_test, lgtc_l, MAH_K, early_l, late_l
     )
 
     log_mah_e_bn = "log_mah_vs_time_rockstar_default_logmp_{0:.1f}_early.dat"
@@ -72,14 +71,12 @@ def test_calc_halo_history_scalar_agrees_with_vmap():
     tarr = np.linspace(0.1, 14, 15)
     logt = np.log10(tarr)
     logtmp = logt[-1]
-    logmp = 12.0
-    lgtc, k, ue, ul = list(DEFAULT_MAH_PARAMS.values())
-    early, late = _get_early_late(ue, ul)
-    dmhdt, log_mah = _calc_halo_history(logt, logtmp, logmp, lgtc, k, early, late)
+    lgmp, lgtc, early, late = DEFAULT_MAH_PARAMS
+    dmhdt, log_mah = _calc_halo_history(logt, logtmp, lgmp, lgtc, MAH_K, early, late)
 
     for i, t in enumerate(tarr):
         lgt_i = jnp.log10(t)
-        res = _calc_halo_history_scalar(lgt_i, logtmp, logmp, lgtc, k, early, late)
+        res = _calc_halo_history_scalar(lgt_i, logtmp, lgmp, lgtc, MAH_K, early, late)
         dmhdt_i, log_mah_i = res
         assert np.allclose(dmhdt[i], dmhdt_i)
         assert np.allclose(log_mah[i], log_mah_i)

--- a/diffmah/tng_pdf_model.py
+++ b/diffmah/tng_pdf_model.py
@@ -7,12 +7,11 @@ from jax import lax
 from jax import numpy as jnp
 from jax import vmap
 
-from .individual_halo_assembly import DEFAULT_MAH_PARAMS
+from .defaults import MAH_K
 from .utils import get_cholesky_from_params
 
 TODAY = 13.8
 LGT0 = jnp.log10(TODAY)
-K = DEFAULT_MAH_PARAMS["mah_k"]
 
 _LGM_X0, LGM_K = 13.0, 0.5
 
@@ -353,7 +352,7 @@ def _get_mah_means_and_covs(
     chol_ue_lgtc_late_yhi=DEFAULT_MAH_PDF_PARAMS["chol_ue_lgtc_late_yhi"],
     chol_ul_lgtc_late_ylo=DEFAULT_MAH_PDF_PARAMS["chol_ul_lgtc_late_ylo"],
     chol_ul_lgtc_late_yhi=DEFAULT_MAH_PDF_PARAMS["chol_ul_lgtc_late_yhi"],
-    k=DEFAULT_MAH_PARAMS["mah_k"],
+    k=MAH_K,
     logtmp=LGT0,
 ):
     frac_late = frac_late_forming(logmp_arr, frac_late_ylo, frac_late_yhi)


### PR DESCRIPTION
Eliminate inconsistent usage of DEFAULT_MAH_PARAMS. Also bring in mah_singlehalo and mah_halopop kernels.

This PR introduces an API-breaking change that may be common. The following line is now broken:
`from diffmah.individual_halo_assembly import DEFAULT_MAH_PARAMS`
should be replaced with:
`from diffmah import DEFAULT_MAH_PARAMS`

Note also that this dictionary now stores different parameters: (logmp, logtc, early, late)