### PR TITLE
Add trimmed mean and variance calculators

### DIFF
--- a/.github/workflows/monthly-warning-test.yml
+++ b/.github/workflows/monthly-warning-test.yml
@@ -43,6 +43,7 @@ jobs:
             setuptools \
             "setuptools_scm>=7,<8" \
             python-build \
+            scipy \
             flake8-pyproject
           python -m pip install --no-build-isolation --no-deps -e .
 

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -44,6 +44,7 @@ jobs:
             pip \
             setuptools \
             "setuptools_scm>=7,<8" \
+            scipy \
             python-build
           python -m pip install --no-build-isolation --no-deps -e .
 


### PR DESCRIPTION
New `trimmed_mean` and `trimmed_mean_and_variance` functions are JAX implementations of the corresponding functions implemented in `jax.stats.mstats`. Unit tests enforce identical behavior.