### PR TITLE
Calibration of average halo MAH predictions

### DIFF
--- a/diffmah/diffmahpop_kernels/early_index_pop.py
+++ b/diffmah/diffmahpop_kernels/early_index_pop.py
@@ -17,11 +17,11 @@ EARLY_INDEX_YLO_K = 1.0
 EARLY_INDEX_YHI_X0 = 8.0
 
 EARLY_INDEX_PDICT = OrderedDict(
-    early_index_ylo_x0=5.48,
-    early_index_ylo_ylo=1.91,
-    early_index_ylo_yhi=1.32,
-    early_index_yhi_ylo=3.27,
-    early_index_yhi_yhi=2.77,
+    early_index_ylo_x0=6.497,
+    early_index_ylo_ylo=3.109,
+    early_index_ylo_yhi=1.500,
+    early_index_yhi_ylo=3.347,
+    early_index_yhi_yhi=2.915,
 )
 EARLY_INDEX_BOUNDS_PDICT = OrderedDict(
     early_index_ylo_x0=(1.0, 7.0),

--- a/diffmah/diffmahpop_kernels/ftpt0_cens.py
+++ b/diffmah/diffmahpop_kernels/ftpt0_cens.py
@@ -14,7 +14,7 @@ T0_C0 = 10.0
 LGM0_FTPT0 = 12.0
 EPS = 1e-4
 
-DEFAULT_FTPT0_PDICT = OrderedDict(ftpt0_c0_c0=0.5, ftpt0_c0_c1=0.025, ftpt0_c1=0.05)
+DEFAULT_FTPT0_PDICT = OrderedDict(ftpt0_c0_c0=0.313, ftpt0_c0_c1=0.076, ftpt0_c1=0.101)
 
 FTPT0_BOUNDS = (0.01, 0.99)
 FTPT0_PBOUNDS_PDICT = OrderedDict(

--- a/diffmah/diffmahpop_kernels/late_index_pop.py
+++ b/diffmah/diffmahpop_kernels/late_index_pop.py
@@ -12,7 +12,10 @@ from ..utils import _inverse_sigmoid, _sigmoid
 LATE_INDEX_X0 = 12.5
 LATE_INDEX_K = 1.0
 
-LATE_INDEX_PDICT = OrderedDict(late_index_ylo=0.128, late_index_yhi=0.128)
+LATE_INDEX_PDICT = OrderedDict(
+    late_index_ylo=0.191,
+    late_index_yhi=0.194,
+)
 LATE_INDEX_BOUNDS_PDICT = OrderedDict(
     late_index_ylo=(0.01, 0.2), late_index_yhi=(0.01, 0.2)
 )

--- a/diffmah/diffmahpop_kernels/logm0_kernels/logm0_c0_kernels.py
+++ b/diffmah/diffmahpop_kernels/logm0_kernels/logm0_c0_kernels.py
@@ -11,10 +11,10 @@ from ...bfgs_wrapper import diffmah_fitter
 from ...utils import _inverse_sigmoid, _sig_slope, _sigmoid
 
 DEFAULT_LGM0POP_C0_PDICT = OrderedDict(
-    lgm0pop_c0_ytp=0.16,
-    lgm0pop_c0_ylo=-0.094,
-    lgm0pop_c0_clip_c0=0.723,
-    lgm0pop_c0_clip_c1=-0.0541,
+    lgm0pop_c0_ytp=0.025,
+    lgm0pop_c0_ylo=-0.077,
+    lgm0pop_c0_clip_c0=0.546,
+    lgm0pop_c0_clip_c1=-0.088,
 )
 LGM0Pop_C0_Params = namedtuple("LGM0Pop_C0_Params", DEFAULT_LGM0POP_C0_PDICT.keys())
 DEFAULT_LGM0POP_C0_PARAMS = LGM0Pop_C0_Params(**DEFAULT_LGM0POP_C0_PDICT)

--- a/diffmah/diffmahpop_kernels/logm0_kernels/logm0_c1_kernels.py
+++ b/diffmah/diffmahpop_kernels/logm0_kernels/logm0_c1_kernels.py
@@ -11,11 +11,11 @@ from ...bfgs_wrapper import diffmah_fitter
 from ...utils import _inverse_sigmoid, _sig_slope, _sigmoid
 
 DEFAULT_LGM0POP_C1_PDICT = OrderedDict(
-    lgm0pop_c1_ytp=0.0266,
-    lgm0pop_c1_ylo=-0.0176,
-    lgm0pop_c1_clip_x0=7.452,
-    lgm0pop_c1_clip_ylo=0.0825,
-    lgm0pop_c1_clip_yhi=0.0215,
+    lgm0pop_c1_ytp=0.005,
+    lgm0pop_c1_ylo=-0.034,
+    lgm0pop_c1_clip_x0=4.977,
+    lgm0pop_c1_clip_ylo=0.140,
+    lgm0pop_c1_clip_yhi=0.002,
 )
 LGM0Pop_C1_Params = namedtuple("LGM0Pop_C1_Params", DEFAULT_LGM0POP_C1_PDICT.keys())
 DEFAULT_LGM0POP_C1_PARAMS = LGM0Pop_C1_Params(**DEFAULT_LGM0POP_C1_PDICT)

--- a/diffmah/diffmahpop_kernels/mc_diffmahpop_kernels.py
+++ b/diffmah/diffmahpop_kernels/mc_diffmahpop_kernels.py
@@ -115,58 +115,44 @@ def multiloss_vmap(
     return jnp.sum(losses)
 
 
-@jjit
-def _loss_kern_singlehalo(diffmahpop_params, loss_data):
-    tarr, lgm_obs, t_obs, ran_key, lgt0, avg_log_mah_target = loss_data
-    avg_log_mah_pred = mc_tp_avg_mah_singlecen(
-        diffmahpop_params, tarr, lgm_obs, t_obs, ran_key, lgt0
-    )
-    loss = _mse(avg_log_mah_pred, avg_log_mah_target)
-    return loss
+multiloss_and_grads_vmap = jjit(value_and_grad(multiloss_vmap))
 
 
 @jjit
-def _loss_kern_singlehalo_u_params(diffmahpop_u_params, loss_data):
-    diffmahpop_u_params = DEFAULT_DIFFMAHPOP_U_PARAMS._make(diffmahpop_u_params)
-    diffmahpop_params = get_diffmahpop_params_from_u_params(diffmahpop_u_params)
-    return _loss_kern_singlehalo(diffmahpop_params, loss_data)
-
-
-@jjit
-def _loss_kern_singlehalo_subset_u_params(diffmahpop_subset_u_params, loss_data):
-
+def _loss_scalar_kern_subset_u_params(
+    diffmahpop_subset_u_params, tarr, lgm_obs, t_obs, ran_key, lgt0, avg_log_mah_target
+):
     diffmahpop_u_params = DEFAULT_DIFFMAHPOP_U_PARAMS._replace(
         **diffmahpop_subset_u_params._asdict()
     )
     diffmahpop_params = get_diffmahpop_params_from_u_params(diffmahpop_u_params)
-    return _loss_kern_singlehalo(diffmahpop_params, loss_data)
+    args = diffmahpop_params, tarr, lgm_obs, t_obs, ran_key, lgt0, avg_log_mah_target
+    return _loss_scalar_kern(*args)
+
+
+_A = (None, 0, 0, 0, 0, None, 0)
+_loss_vmap_kern_subset_u_params = jjit(
+    vmap(_loss_scalar_kern_subset_u_params, in_axes=_A)
+)
 
 
 @jjit
-def _loss_kern_multihalo_u_params(diffmahpop_u_params, loss_data_collection):
-    loss = 0.0
-    for loss_data in loss_data_collection:
-        loss = loss + _loss_kern_singlehalo_u_params(diffmahpop_u_params, loss_data)
-    return loss
+def multiloss_vmap_subset_u_params(diffmahpop_subset_u_params, loss_data):
+    tarr, lgm_obs, t_obs, ran_key, lgt0, avg_log_mah_target = loss_data
+    losses = _loss_vmap_kern_subset_u_params(
+        diffmahpop_subset_u_params,
+        tarr,
+        lgm_obs,
+        t_obs,
+        ran_key,
+        lgt0,
+        avg_log_mah_target,
+    )
+    return jnp.sum(losses)
 
 
-loss_and_grads_multihalo = jjit(value_and_grad(_loss_kern_multihalo_u_params))
-
-
-@jjit
-def _loss_kern_multihalo_subset_u_params(
-    diffmahpop_subset_u_params, loss_data_collection
-):
-    loss = 0.0
-    for loss_data in loss_data_collection:
-        loss = loss + _loss_kern_singlehalo_subset_u_params(
-            diffmahpop_subset_u_params, loss_data
-        )
-    return loss
-
-
-loss_and_grads_multihalo_subset = jjit(
-    value_and_grad(_loss_kern_multihalo_subset_u_params)
+multiloss_and_grads_vmap_subset_u_params = jjit(
+    value_and_grad(multiloss_vmap_subset_u_params)
 )
 
 


### PR DESCRIPTION
This PR brings in code to run gradient descents on predictions for average halo mass growth as a function of `M_obs, t_obs`. This plot shows the accuracy level of the new default parameters updated with this PR. 

![diffmahpop_calibration_mean_mah](https://github.com/ArgonneCPAC/diffmah/assets/6951595/10fc1552-2fcc-4b62-9eb8-c47248d88fa0)

So far we're still only predicting the mean relation, and so the next step from here is to start making predictions for the variance.

There is also some bug leading to NaN gradients in the parameters controlling the $P(t_{\rm peak})$. The [tp_pdf_cens.py](https://github.com/ArgonneCPAC/diffmah/blob/3ca4f02c85fa89082f49f749bdd792e87d1ac548/diffmah/diffmahpop_kernels/t_peak_kernels/tp_pdf_cens.py) module is where the model is defined, but I think the problem is probably to do with the way the Monte Carlo generation of $t_{\rm peak}$ is being done [here](https://github.com/ArgonneCPAC/diffmah/blob/3ca4f02c85fa89082f49f749bdd792e87d1ac548/diffmah/diffmahpop_kernels/mc_diffmahpop_kernels.py#L46) in the code (we might need to do PDF-weighting rather than Monte Carlo, for example).