### PR TITLE
Update default parameters according to gradient descent for centrals

### DIFF
--- a/diffmah/diffmahpop_kernels/covariance_kernels.py
+++ b/diffmah/diffmahpop_kernels/covariance_kernels.py
@@ -19,20 +19,20 @@ COV_LGM_K = 2.0
 
 K_BOUNDING = 0.1
 DEFAULT_COV_PDICT = OrderedDict(
-    std_u_logm0_ylo=0.25,
-    std_u_logtc_ylo=0.25,
-    std_u_early_ylo=0.25,
-    std_u_late_ylo=0.25,
-    std_u_logm0_yhi=0.25,
-    std_u_logtc_yhi=0.25,
-    std_u_early_yhi=0.25,
-    std_u_late_yhi=0.25,
-    rho_logtc_logm0=0.0,
-    rho_early_logm0=0.0,
-    rho_early_logtc=0.0,
-    rho_late_logm0=0.0,
-    rho_late_logtc=0.0,
-    rho_late_early=0.0,
+    std_u_logm0_ylo=0.290,
+    std_u_logtc_ylo=0.374,
+    std_u_early_ylo=2.610,
+    std_u_late_ylo=1.453,
+    std_u_logm0_yhi=0.798,
+    std_u_logtc_yhi=0.890,
+    std_u_early_yhi=2.956,
+    std_u_late_yhi=2.897,
+    rho_logtc_logm0=-0.114,
+    rho_early_logm0=-0.199,
+    rho_early_logtc=0.200,
+    rho_late_logm0=-0.166,
+    rho_late_logtc=0.132,
+    rho_late_early=0.232,
 )
 
 STD_BOUNDS = (0.01, 100.0)

--- a/diffmah/diffmahpop_kernels/early_index_pop.py
+++ b/diffmah/diffmahpop_kernels/early_index_pop.py
@@ -20,11 +20,11 @@ EARLY_INDEX_YLO_K = 1.0
 EARLY_INDEX_YHI_X0 = 8.0
 
 EARLY_INDEX_PDICT = OrderedDict(
-    early_index_ylo_x0=6.497,
-    early_index_ylo_ylo=3.109,
-    early_index_ylo_yhi=1.500,
-    early_index_yhi_ylo=3.347,
-    early_index_yhi_yhi=2.915,
+    early_index_ylo_x0=6.789,
+    early_index_ylo_ylo=3.386,
+    early_index_ylo_yhi=1.118,
+    early_index_yhi_ylo=3.164,
+    early_index_yhi_yhi=2.991,
 )
 EARLY_INDEX_BOUNDS_PDICT = OrderedDict(
     early_index_ylo_x0=(1.0, 7.0),

--- a/diffmah/diffmahpop_kernels/ftpt0_cens.py
+++ b/diffmah/diffmahpop_kernels/ftpt0_cens.py
@@ -14,7 +14,7 @@ T0_C0 = 10.0
 LGM0_FTPT0 = 12.0
 EPS = 1e-4
 
-DEFAULT_FTPT0_PDICT = OrderedDict(ftpt0_c0_c0=0.313, ftpt0_c0_c1=0.076, ftpt0_c1=0.101)
+DEFAULT_FTPT0_PDICT = OrderedDict(ftpt0_c0_c0=0.081, ftpt0_c0_c1=0.041, ftpt0_c1=0.044)
 
 FTPT0_BOUNDS = (0.01, 0.99)
 FTPT0_PBOUNDS_PDICT = OrderedDict(

--- a/diffmah/diffmahpop_kernels/late_index_pop.py
+++ b/diffmah/diffmahpop_kernels/late_index_pop.py
@@ -15,8 +15,8 @@ LATE_INDEX_X0 = 12.5
 LATE_INDEX_K = 1.0
 
 LATE_INDEX_PDICT = OrderedDict(
-    late_index_ylo=0.191,
-    late_index_yhi=0.194,
+    late_index_ylo=0.181,
+    late_index_yhi=0.189,
 )
 LATE_INDEX_BOUNDS_PDICT = OrderedDict(
     late_index_ylo=(0.01, 0.2), late_index_yhi=(0.01, 0.2)

--- a/diffmah/diffmahpop_kernels/logm0_kernels/logm0_c0_kernels.py
+++ b/diffmah/diffmahpop_kernels/logm0_kernels/logm0_c0_kernels.py
@@ -11,10 +11,10 @@ from ...bfgs_wrapper import diffmah_fitter
 from ...utils import _inverse_sigmoid, _sig_slope, _sigmoid
 
 DEFAULT_LGM0POP_C0_PDICT = OrderedDict(
-    lgm0pop_c0_ytp=0.025,
-    lgm0pop_c0_ylo=-0.077,
-    lgm0pop_c0_clip_c0=0.546,
-    lgm0pop_c0_clip_c1=-0.088,
+    lgm0pop_c0_ytp=0.031,
+    lgm0pop_c0_ylo=-0.094,
+    lgm0pop_c0_clip_c0=0.639,
+    lgm0pop_c0_clip_c1=-0.090,
 )
 LGM0Pop_C0_Params = namedtuple("LGM0Pop_C0_Params", DEFAULT_LGM0POP_C0_PDICT.keys())
 DEFAULT_LGM0POP_C0_PARAMS = LGM0Pop_C0_Params(**DEFAULT_LGM0POP_C0_PDICT)

--- a/diffmah/diffmahpop_kernels/logm0_kernels/logm0_c1_kernels.py
+++ b/diffmah/diffmahpop_kernels/logm0_kernels/logm0_c1_kernels.py
@@ -11,10 +11,10 @@ from ...bfgs_wrapper import diffmah_fitter
 from ...utils import _inverse_sigmoid, _sig_slope, _sigmoid
 
 DEFAULT_LGM0POP_C1_PDICT = OrderedDict(
-    lgm0pop_c1_ytp=0.005,
-    lgm0pop_c1_ylo=-0.034,
-    lgm0pop_c1_clip_x0=4.977,
-    lgm0pop_c1_clip_ylo=0.140,
+    lgm0pop_c1_ytp=0.004,
+    lgm0pop_c1_ylo=-0.030,
+    lgm0pop_c1_clip_x0=5.102,
+    lgm0pop_c1_clip_ylo=0.143,
     lgm0pop_c1_clip_yhi=0.002,
 )
 LGM0Pop_C1_Params = namedtuple("LGM0Pop_C1_Params", DEFAULT_LGM0POP_C1_PDICT.keys())

--- a/diffmah/diffmahpop_kernels/logtc_pop.py
+++ b/diffmah/diffmahpop_kernels/logtc_pop.py
@@ -13,11 +13,11 @@ from ..utils import _inverse_sigmoid, _sig_slope, _sigmoid
 EPS = 1e-3
 K_BOUNDING = 0.1
 LOGTC_PDICT = OrderedDict(
-    lgm_c0_tp_ytp_tobs_c0=0.471,
-    lgm_c0_tp_ytp_tobs_c1=0.021,
-    lgm_c0_tp_ylo=0.052,
-    lgm_c0_tp_yhi=-0.045,
-    lgm_c1=0.104,
+    lgm_c0_tp_ytp_tobs_c0=0.395,
+    lgm_c0_tp_ytp_tobs_c1=0.018,
+    lgm_c0_tp_ylo=0.067,
+    lgm_c0_tp_yhi=-0.071,
+    lgm_c1=0.106,
 )
 LOGTC_BOUNDS_PDICT = OrderedDict(
     lgm_c0_tp_ytp_tobs_c0=(0.2, 0.9),

--- a/diffmah/diffmahpop_kernels/t_peak_kernels/tp_pdf_cens.py
+++ b/diffmah/diffmahpop_kernels/t_peak_kernels/tp_pdf_cens.py
@@ -14,9 +14,9 @@ from . import utp_pdf_kernels as tpk
 LOC_T_OBS_K = 1.0
 
 DEFAULT_TPCENS_PDICT = OrderedDict(
-    tpck_scale_boost_early=0.2,
-    tpck_scale_mh_lo=0.27,
-    tpck_scale_mh_hi=0.15,
+    tpck_scale_boost_early=0.314,
+    tpck_scale_mh_lo=0.469,
+    tpck_scale_mh_hi=0.292,
 )
 
 TPCENS_PBOUNDS_PDICT = OrderedDict(


### PR DESCRIPTION
This PR brings in a new set of default parameters for DiffmahPop. These parameters were derived based on a gradient descent with the following two constraints:

1. $\langle M_{\rm h}(t)\ \vert\ M_{\rm obs},\ t_{\rm obs}\rangle$
2. $\sigma\left(M_{\rm h}(t)\ \vert\ M_{\rm obs},\ t_{\rm obs}\right)$

Here are a couple of example plots showing the accuracy of the calibration.
![diffmahpop_mu_var_4panel_validation](https://github.com/user-attachments/assets/4f196011-d19c-4988-9202-697556a8c87c)
![diffmahpop_mu_var_4panel_residuals](https://github.com/user-attachments/assets/aa9b14df-063c-4dc7-944a-8240c31eb096)
