### PR TITLE
Install kdescent into testing workflow

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -46,6 +46,7 @@ jobs:
             "setuptools_scm>=7,<8" \
             scipy \
             python-build
+          pip install --no-deps git+https://github.com/AlanPearl/kdescent.git
           python -m pip install --no-build-isolation --no-deps -e .
 
       - name: test

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -45,7 +45,10 @@ jobs:
             setuptools \
             "setuptools_scm>=7,<8" \
             scipy \
-            python-build
+            python-build \
+            jaxopt \
+            optax \
+            tqdm
           pip install --no-deps git+https://github.com/AlanPearl/kdescent.git
           python -m pip install --no-build-isolation --no-deps -e .
 

--- a/diffmah/tests/test_kdescent_installation.py
+++ b/diffmah/tests/test_kdescent_installation.py
@@ -1,0 +1,11 @@
+"""
+"""
+
+try:
+    import kdescent
+except ImportError:
+    pass
+
+
+def test_kdescent_is_installed():
+    kdescent


### PR DESCRIPTION
Throwaway PR for checking that the [kdescent](https://github.com/AlanPearl/kdescent) code has been correctly incorporated into our CI workflow. The new unit test should pass when run within `tests.yml`.