### PR TITLE
Adding scalar function for dmhdt

### DIFF
--- a/diffmah/diffmah_kernels.py
+++ b/diffmah/diffmah_kernels.py
@@ -124,6 +124,13 @@ def _dmhdt_kern(mah_params, t, t_peak, logt0):
 
 
 @jjit
+def _dmhdt_kern_scalar(mah_params, t, t_peak, logt0):
+    dmhdt_noq = _dmhdt_noq_kern_scalar(mah_params, t, logt0)
+    dmhdt = jnp.where(t > t_peak, 0.0, dmhdt_noq)
+    return dmhdt
+
+
+@jjit
 def _diffmah_kern(mah_params, t, t_peak, logt0):
     dmhdt = _dmhdt_kern(mah_params, t, t_peak, logt0)
     log_mah = _log_mah_kern(mah_params, t, t_peak, logt0)


### PR DESCRIPTION
Adding scalar function for dmhdt. Useful for `diffstar.main_sequence_kernels_tpeak _lax_ms_sfh_scalar_kern_scan` function.