### PR TITLE
Update fitting_helpers.py module

### DIFF
--- a/diffmah/fitting_helpers.py
+++ b/diffmah/fitting_helpers.py
@@ -152,18 +152,16 @@ def _check_for_logmah_vs_mah_mistake(mah_sim):
 def write_collated_data(outname, fit_data_strings, chunk_arr=None):
     import h5py
 
-    halo_id = fit_data_strings[:, 0].astype(int)
-    logm0 = fit_data_strings[:, 1].astype(float)
-    logtc = fit_data_strings[:, 2].astype(float)
-    early_index = fit_data_strings[:, 3].astype(float)
-    late_index = fit_data_strings[:, 4].astype(float)
-    t_peak = fit_data_strings[:, 5].astype(float)
-    loss = fit_data_strings[:, 6].astype(float)
-    n_points_per_fit = fit_data_strings[:, 7].astype(int)
-    fit_algo = fit_data_strings[:, 8].astype(int)
+    logm0 = fit_data_strings[:, 0].astype(float)
+    logtc = fit_data_strings[:, 1].astype(float)
+    early_index = fit_data_strings[:, 2].astype(float)
+    late_index = fit_data_strings[:, 3].astype(float)
+    t_peak = fit_data_strings[:, 4].astype(float)
+    loss = fit_data_strings[:, 5].astype(float)
+    n_points_per_fit = fit_data_strings[:, 6].astype(int)
+    fit_algo = fit_data_strings[:, 7].astype(int)
 
     with h5py.File(outname, "w") as hdf:
-        hdf["halo_id"] = halo_id
         hdf["logm0"] = logm0
         hdf["logtc"] = logtc
         hdf["early_index"] = early_index

--- a/diffmah/fitting_helpers.py
+++ b/diffmah/fitting_helpers.py
@@ -45,12 +45,17 @@ def diffmah_fitter(
     u_p_init, loss_data, skip_fit = get_loss_data(
         t_sim, log_mah_sim, lgm_min, dlogm_cut, t_fit_min
     )
-    _res = bfgs_adam_fallback(loss_and_grads_kern, u_p_init, loss_data, nstep, n_warmup)
-    u_p_best, loss_best, fit_terminates, code_used = _res
-    u_t_peak = loss_data[2]
-    u_p_best = dk.DEFAULT_MAH_U_PARAMS._make((*u_p_best, u_t_peak))
-    p_best = dk.get_bounded_mah_params(u_p_best)
-    return p_best, loss_best, fit_terminates, code_used, loss_data
+    if skip_fit:
+        raise NotImplementedError
+    else:
+        _res = bfgs_adam_fallback(
+            loss_and_grads_kern, u_p_init, loss_data, nstep, n_warmup
+        )
+        u_p_best, loss_best, fit_terminates, code_used = _res
+        u_t_peak = loss_data[2]
+        u_p_best = dk.DEFAULT_MAH_U_PARAMS._make((*u_p_best, u_t_peak))
+        p_best = dk.get_bounded_mah_params(u_p_best)
+        return p_best, loss_best, fit_terminates, code_used, loss_data
 
 
 def write_collated_data(outname, fit_data_strings, chunk_arr=None):

--- a/diffmah/fitting_helpers.py
+++ b/diffmah/fitting_helpers.py
@@ -49,7 +49,7 @@ def diffmah_fitter(
     u_t_peak = loss_data[2]
     u_p_best = dk.DEFAULT_MAH_U_PARAMS._make((*u_p_best, u_t_peak))
     p_best = dk.get_bounded_mah_params(u_p_best)
-    return p_best, loss_best, fit_terminates, code_used
+    return p_best, loss_best, fit_terminates, code_used, loss_data
 
 
 def write_collated_data(outname, fit_data_strings, chunk_arr=None):

--- a/diffmah/fitting_helpers.py
+++ b/diffmah/fitting_helpers.py
@@ -171,9 +171,6 @@ def write_collated_data(outname, fit_data_strings, chunk_arr=None):
         hdf["n_points_per_fit"] = n_points_per_fit
         hdf["fit_algo"] = fit_algo
 
-        if chunk_arr is not None:
-            hdf["chunk"] = chunk_arr
-
 
 @jjit
 def compute_indx_t_peak_singlehalo(log_mah_table):

--- a/diffmah/fitting_helpers.py
+++ b/diffmah/fitting_helpers.py
@@ -1,5 +1,4 @@
-"""Utility functions for fitting MAHs with diffmah.
-Data loading functions require h5py and/or haccytrees
+"""Module implements diffmah_fitter for fitting MAHs with diffmah
 
 """
 
@@ -42,6 +41,62 @@ def diffmah_fitter(
     nstep=200,
     n_warmup=1,
 ):
+    """Fit simulated MAH with diffmah
+
+    Parameters
+    ----------
+    t_sim : array, shape (n_t, )
+        Age of the universe in Gyr
+
+    mah_sim : array, shape (n_t, )
+        Halo mass in units of Msun/h
+
+    lgm_min : float, optional
+        Minimum halo mass to use input halo data in the fitter. Default is -inf.
+
+    dlogm_cut : float, optional
+        Maximum change in log10(MAH) from z=0 mass to use input halo data in the fitter.
+        Default is DLOGM_CUT.
+
+    t_fit_min : float, optional
+        Minimum time to use input halo data in the fitter. Default is T_FIT_MIN.
+
+    nstep : int
+        Number of gradient descent steps to use in fitter. Default is 200.
+        Only applies to cases where BFGS fails and Adam is used.
+
+    n_warmup : int
+        Number of warmup iterations in gradient descent. Default is 1.
+        Only applies to cases where BFGS fails and Adam is used.
+
+    Returns
+    -------
+    p_best : namedtuple
+        Best-fit diffmah parameters
+
+    loss_best : float
+        MSE loss of best-fit parameters
+
+    skip_fit : bool
+        True if the fitter was not run at all due to insufficient input MAH data
+
+    fit_terminates : bool
+        True if the fitter ran to completion
+
+    code_used : int
+        0 for BFGS, 1 for Adam, -1 if skip_fit is True
+
+    loss_data : tuple
+        t_target, log_mah_target, u_t_peak, logt0 = loss_data
+
+        * u_t_peak is the unbounded version of the diffmah t_peak parameter
+        * logt0 is base-10 log of the z=0 age of the universe in Gyr
+
+    Notes
+    -----
+    Note that the input data is the MAH, not log10(MAH)
+
+    """
     _check_for_logmah_vs_mah_mistake(mah_sim)
 
     u_p_init, loss_data, skip_fit = get_loss_data(

--- a/diffmah/fitting_helpers.py
+++ b/diffmah/fitting_helpers.py
@@ -16,7 +16,7 @@ from .bfgs_wrapper import bfgs_adam_fallback
 
 DLOGM_CUT = 2.5
 T_FIT_MIN = 1.0
-NPTS_FIT_MIN = 3  # Number of non-trivial points in the MAH
+NPTS_FIT_MIN = 3  # Number of non-trivial points in the MAH, excluding MAH(z=0)
 NOFIT_FILL = -99.0
 EPSILON = 1e-7
 

--- a/diffmah/fitting_helpers.py
+++ b/diffmah/fitting_helpers.py
@@ -3,7 +3,6 @@ Data loading functions require h5py and/or haccytrees
 
 """
 
-import os
 from collections import namedtuple
 from copy import deepcopy
 
@@ -179,10 +178,10 @@ loss_and_grads_kern = jjit(value_and_grad(log_mah_loss_uparams))
 def get_outline_bad_fit(halo_id, loss_data, npts_mah, algo):
     log_mah_target = loss_data[1]
     logm0 = log_mah_target[-1]
-    logtc, early, late = -1.0, -1.0, -1.0
+    logtc, early, late = NOFIT_FILL, NOFIT_FILL, NOFIT_FILL
     u_t_peak = loss_data[2]
     t_peak = dk._get_bounded_diffmah_param(u_t_peak, dk.MAH_PBOUNDS.t_peak)
-    loss_best = -1.0
+    loss_best = NOFIT_FILL
     _floats = (logm0, logtc, early, late, t_peak, loss_best)
     out_list = ["{:.5e}".format(float(x)) for x in _floats]
     out_list = [str(x) for x in out_list]

--- a/diffmah/fitting_helpers.py
+++ b/diffmah/fitting_helpers.py
@@ -35,7 +35,7 @@ LJ_h = 0.6766
 def diffmah_fitter(
     t_sim,
     log_mah_sim,
-    lgm_min,
+    lgm_min=-float("inf"),
     dlogm_cut=DLOGM_CUT,
     t_fit_min=T_FIT_MIN,
     nstep=200,

--- a/diffmah/tests/test_fitting_helpers.py
+++ b/diffmah/tests/test_fitting_helpers.py
@@ -80,7 +80,7 @@ def test_diffmah_fitter():
         log_mah_target = log_mah_sim + log_mah_noise
 
         _res = fithelp.diffmah_fitter(t_sim, log_mah_target, lgm_min)
-        p_best, loss_best, fit_terminates, code_used = _res
+        p_best, loss_best, fit_terminates, code_used, loss_data = _res
         __, log_mah_fit = dk.mah_singlehalo(p_best, t_sim, LGT0)
         loss_check = fithelp._mse(log_mah_fit, log_mah_sim)
         assert loss_check < 0.01

--- a/diffmah/tests/test_fitting_helpers.py
+++ b/diffmah/tests/test_fitting_helpers.py
@@ -84,3 +84,31 @@ def test_diffmah_fitter():
         __, log_mah_fit = dk.mah_singlehalo(p_best, t_sim, LGT0)
         loss_check = fithelp._mse(log_mah_fit, log_mah_sim)
         assert loss_check < 0.01
+
+
+def test_get_target_data():
+    t_sim = np.linspace(0.1, 13.8, 100)
+    log_mah_sim = np.linspace(1, 14, t_sim.size)
+    dlogm_cut = 20.0
+    t_fit_min = 0.0
+
+    # No data points should be excluded
+    lgm_min = 0.0
+    logt_target, log_mah_target = fithelp.get_target_data(
+        t_sim, log_mah_sim, lgm_min, dlogm_cut, t_fit_min
+    )
+    assert log_mah_target.size == log_mah_sim.size
+
+    # First data point should be excluded
+    lgm_min = 1.001
+    logt_target, log_mah_target = fithelp.get_target_data(
+        t_sim, log_mah_sim, lgm_min, dlogm_cut, t_fit_min
+    )
+    assert log_mah_target.size == log_mah_sim.size - 1
+
+    # All data points should be excluded
+    lgm_min = 21.001
+    logt_target, log_mah_target = fithelp.get_target_data(
+        t_sim, log_mah_sim, lgm_min, dlogm_cut, t_fit_min
+    )
+    assert len(log_mah_target) == 0

--- a/diffmah/tests/test_fitting_helpers.py
+++ b/diffmah/tests/test_fitting_helpers.py
@@ -11,7 +11,7 @@ from .. import fitting_helpers as fithelp
 from ..bfgs_wrapper import bfgs_adam_fallback
 
 
-def test_fitting_helpers_integration():
+def test_fitting_helpers_component_functions():
     t_sim = np.linspace(0.1, 13.8, 2000)
     logt = np.log10(t_sim)
     logt0 = logt[-1]
@@ -38,25 +38,12 @@ def test_fitting_helpers_integration():
 
     ATOL = 0.1
 
+    assert not skip_fit
     assert fit_terminates
     assert code_used == 0
     assert loss_best < 0.001
     p_best_inferred = dk.get_bounded_mah_params(dk.DiffmahUParams(*u_p_best, u_t_peak))
     assert np.allclose(p_best_inferred, p_true, rtol=ATOL)
-    npts_mah = log_mah_target.size
-
-    root_indx = 123
-    outline = fithelp.get_outline(
-        root_indx, loss_data, u_p_best, loss_best, npts_mah, code_used
-    )
-    outdata = [float(x) for x in outline.strip().split()]
-    header_data = fithelp.HEADER[1:].strip().split()
-    assert len(header_data) == len(outdata)
-    assert np.allclose(outdata[1], logm0, rtol=ATOL)
-    assert np.allclose(outdata[2], logtc, rtol=ATOL)
-    assert np.allclose(outdata[3], early, rtol=ATOL)
-    assert np.allclose(outdata[4], late, rtol=ATOL)
-    assert np.allclose(outdata[5], t_peak, rtol=ATOL)
 
 
 def test_diffmah_fitter():
@@ -199,3 +186,61 @@ def test_diffmah_fitter_raises_warning_when_passed_log_mah_instead_of_mah():
         fithelp.diffmah_fitter(t_sim, log_mah_sim)
     substr = "Values of input MAH are suspiciously small"
     assert substr in str(w[-1].message)
+
+
+def test_get_outline_good_fits():
+    ran_key = jran.key(0)
+    LGT0 = np.log10(13.79)
+
+    t_sim = np.linspace(0.5, 13.8, 100)
+    lgm_min = 7.0
+
+    n_tests = 20
+    for __ in range(n_tests):
+        test_key, noise_key, ran_key = jran.split(ran_key, 3)
+
+        u_p = np.array(dk.DEFAULT_MAH_U_PARAMS)
+        uran = jran.uniform(test_key, minval=-20, maxval=20, shape=u_p.shape)
+        u_p = dk.DEFAULT_MAH_U_PARAMS._make(u_p + uran)
+        mah_params = dk.get_bounded_mah_params(u_p)
+        mah_sim = 10 ** dk.mah_singlehalo(mah_params, t_sim, LGT0)[1]
+
+        log_mah_noise = jran.uniform(
+            noise_key, minval=-0.5, maxval=0.5, shape=mah_sim.shape
+        )
+        mah_target = 10 ** (np.log10(mah_sim) + log_mah_noise)
+
+        fit_results = fithelp.diffmah_fitter(t_sim, mah_target, lgm_min)
+
+        outline = fithelp.get_outline(fit_results)
+        assert outline[-1] == "\n"
+        outdata = fithelp._parse_outline(outline)
+        header_colnames = fithelp.HEADER[1:].strip().split()
+        assert len(outdata) == len(header_colnames)
+
+        assert len(fithelp.DiffmahFitData._fields) == len(outdata)
+
+        ATOL = 1e-4
+        assert np.allclose(outdata.logm0, fit_results.p_best.logm0, rtol=ATOL)
+        assert np.allclose(outdata.logtc, fit_results.p_best.logtc, rtol=ATOL)
+        assert np.allclose(
+            outdata.early_index, fit_results.p_best.early_index, rtol=ATOL
+        )
+        assert np.allclose(outdata.late_index, fit_results.p_best.late_index, rtol=ATOL)
+        assert np.allclose(outdata.t_peak, fit_results.p_best.t_peak, rtol=ATOL)
+
+
+def test_get_outline_bad_fit():
+    t_sim = np.array((1.0, 14.0))
+    mah_sim = np.zeros(2) + 1e10
+    fit_results = fithelp.diffmah_fitter(t_sim, mah_sim)
+    outline = fithelp.get_outline(fit_results)
+    assert outline[-1] == "\n"
+    outdata = fithelp._parse_outline(outline)
+    for pname in dk.DEFAULT_MAH_PARAMS._fields:
+        val = getattr(outdata, pname)
+        assert val == fithelp.NOFIT_FILL
+    assert outdata.loss == fithelp.NOFIT_FILL
+
+    assert outdata.n_points_per_fit == 2
+    assert outdata.fit_algo == -1

--- a/diffmah/tests/test_fitting_helpers.py
+++ b/diffmah/tests/test_fitting_helpers.py
@@ -4,7 +4,6 @@
 import warnings
 
 import numpy as np
-import pytest
 from jax import random as jran
 
 from .. import diffmah_kernels as dk

--- a/diffmah/tests/test_fitting_helpers.py
+++ b/diffmah/tests/test_fitting_helpers.py
@@ -21,7 +21,7 @@ def test_fitting_helpers_integration():
     p_true = dk.DiffmahParams(logm0, logtc, early, late, t_peak)
     log_mah_sim = dk.mah_singlehalo(p_true, t_sim, logt0)[1]
 
-    u_p_init, loss_data = fithelp.get_loss_data(t_sim, log_mah_sim, lgm_min)
+    u_p_init, loss_data, skip_fit = fithelp.get_loss_data(t_sim, log_mah_sim, lgm_min)
     t_target, log_mah_target, u_t_peak, logt0_out = loss_data
     t_peak_inferred = dk._get_bounded_diffmah_param(u_t_peak, dk.MAH_PBOUNDS.t_peak)
     assert np.all(np.isfinite(u_p_init))
@@ -119,3 +119,19 @@ def test_get_target_data():
         t_sim, log_mah_sim, lgm_min, dlogm_cut, t_fit_min
     )
     assert len(log_mah_target) == 0
+
+
+def get_get_loss_data():
+    t_sim = np.linspace(0.1, 13.8, 100)
+    log_mah_sim = np.linspace(1, 14, t_sim.size)
+
+    # No data points should be excluded
+    u_p_init, loss_data, skip_fit = fithelp.get_loss_data(t_sim, log_mah_sim)
+    t_target, log_mah_target, u_t_peak, logt0 = loss_data
+    assert t_target.size == t_sim.size
+    assert log_mah_target.size == log_mah_sim.size
+    assert np.all(np.isfinite(u_t_peak))
+    t0 = 10**logt0
+    assert 5 < t0 < 25
+    assert np.all(np.isfinite(u_p_init))
+    assert len(u_p_init) == len(dk.DEFAULT_MAH_PARAMS) - 1

--- a/diffmah/tests/test_fitting_helpers.py
+++ b/diffmah/tests/test_fitting_helpers.py
@@ -80,7 +80,7 @@ def test_diffmah_fitter():
         log_mah_target = log_mah_sim + log_mah_noise
 
         _res = fithelp.diffmah_fitter(t_sim, log_mah_target, lgm_min)
-        p_best, loss_best, fit_terminates, code_used, loss_data = _res
+        p_best, loss_best, skip_fit, fit_terminates, code_used, loss_data = _res
         __, log_mah_fit = dk.mah_singlehalo(p_best, t_sim, LGT0)
         loss_check = fithelp._mse(log_mah_fit, log_mah_sim)
         assert loss_check < 0.01
@@ -89,9 +89,13 @@ def test_diffmah_fitter():
 def test_diffmah_fitter_skips_mahs_with_insufficient_data():
     t_sim = np.linspace(0.1, 13.8, 100)
     log_mah_sim = np.linspace(1, 14, t_sim.size)
-    _res = fithelp.diffmah_fitter(t_sim, log_mah_sim)
-    p_best, loss_best, fit_terminates, code_used, loss_data = _res
-    raise NotImplementedError()
+    _res = fithelp.diffmah_fitter(t_sim, log_mah_sim, lgm_min=log_mah_sim[-1] + 1)
+    p_best, loss_best, skip_fit, fit_terminates, code_used, loss_data = _res
+    assert skip_fit
+    assert fit_terminates is False
+    assert code_used == -1
+    assert loss_best == fithelp.NOFIT_FILL
+    assert np.allclose(p_best, fithelp.NOFIT_FILL)
 
 
 def test_get_target_data():

--- a/diffmah/tests/test_fitting_helpers.py
+++ b/diffmah/tests/test_fitting_helpers.py
@@ -1,6 +1,8 @@
 """
 """
 
+import warnings
+
 import numpy as np
 from jax import random as jran
 
@@ -188,3 +190,12 @@ def test_get_loss_data():
         t_sim, mah_sim, lgm_min=lgm_min, npts_min=npts_min
     )
     assert skip_fit is False
+
+
+def test_diffmah_fitter_raises_warning_when_passed_log_mah_instead_of_mah():
+    t_sim = np.linspace(0.1, 13.8, 100)
+    log_mah_sim = np.linspace(5, 15, t_sim.size)
+    with warnings.catch_warnings(record=True) as w:
+        fithelp.diffmah_fitter(t_sim, log_mah_sim)
+    substr = "Values of input MAH are suspiciously small"
+    assert substr in str(w[-1].message)

--- a/diffmah/tests/test_fitting_helpers.py
+++ b/diffmah/tests/test_fitting_helpers.py
@@ -4,6 +4,7 @@
 import warnings
 
 import numpy as np
+import pytest
 from jax import random as jran
 
 from .. import diffmah_kernels as dk
@@ -163,7 +164,7 @@ def test_get_loss_data():
     assert np.allclose(log_mah_target, np.log10(mah_sim[msk]))
 
     # Fit should be skipped on account of npts_min cut
-    npts_min = 4
+    npts_min = fithelp.NPTS_FIT_MIN - 2
     lgm_min = np.log10(mah_sim[-npts_min])
     u_p_init, loss_data, skip_fit = fithelp.get_loss_data(
         t_sim, mah_sim, lgm_min=lgm_min, npts_min=npts_min
@@ -171,8 +172,8 @@ def test_get_loss_data():
     assert skip_fit is True
 
     # Fit should NOT be skipped on account of npts_min cut
-    npts_min = 4
-    lgm_min = np.log10(mah_sim[-npts_min - 1])
+    npts_min = fithelp.NPTS_FIT_MIN - 3
+    lgm_min = np.log10(mah_sim[-npts_min])
     u_p_init, loss_data, skip_fit = fithelp.get_loss_data(
         t_sim, mah_sim, lgm_min=lgm_min, npts_min=npts_min
     )
@@ -231,8 +232,9 @@ def test_get_outline_good_fits():
 
 
 def test_get_outline_bad_fit():
-    t_sim = np.array((1.0, 14.0))
-    mah_sim = np.zeros(2) + 1e10
+    """Set up and check a hard-coded example of a no-fit MAH"""
+    t_sim = np.array((2.0, 5.0, 13.0))
+    mah_sim = 10 ** np.array([14.5, 14.75, 15.0])
     fit_results = fithelp.diffmah_fitter(t_sim, mah_sim)
     outline = fithelp.get_outline(fit_results)
     assert outline[-1] == "\n"
@@ -242,5 +244,5 @@ def test_get_outline_bad_fit():
         assert val == fithelp.NOFIT_FILL
     assert outdata.loss == fithelp.NOFIT_FILL
 
-    assert outdata.n_points_per_fit == 2
+    assert outdata.n_points_per_fit == 2, fit_results.loss_data.log_mah_target
     assert outdata.fit_algo == -1

--- a/diffmah/tests/test_fitting_helpers.py
+++ b/diffmah/tests/test_fitting_helpers.py
@@ -86,6 +86,14 @@ def test_diffmah_fitter():
         assert loss_check < 0.01
 
 
+def test_diffmah_fitter_skips_mahs_with_insufficient_data():
+    t_sim = np.linspace(0.1, 13.8, 100)
+    log_mah_sim = np.linspace(1, 14, t_sim.size)
+    _res = fithelp.diffmah_fitter(t_sim, log_mah_sim)
+    p_best, loss_best, fit_terminates, code_used, loss_data = _res
+    raise NotImplementedError()
+
+
 def test_get_target_data():
     t_sim = np.linspace(0.1, 13.8, 100)
     log_mah_sim = np.linspace(1, 14, t_sim.size)

--- a/diffmah/tests/test_fitting_helpers.py
+++ b/diffmah/tests/test_fitting_helpers.py
@@ -99,6 +99,13 @@ def test_get_target_data():
     )
     assert log_mah_target.size == log_mah_sim.size
 
+    # No data points should be excluded
+    lgm_min = -float("inf")
+    logt_target, log_mah_target = fithelp.get_target_data(
+        t_sim, log_mah_sim, lgm_min, dlogm_cut, t_fit_min
+    )
+    assert log_mah_target.size == log_mah_sim.size
+
     # First data point should be excluded
     lgm_min = 1.001
     logt_target, log_mah_target = fithelp.get_target_data(


### PR DESCRIPTION
Updated module reduces boilerplate for scripts that run diffmah fits in parallel.

A few bookkeeping changes introduced here:
* There is no longer a `halo_id` stored in the fit data.
* The fitter now accepts `mah_sim` rather than `log_mah_sim`. A warning is issued if the input seems to be `log_mah_sim`
* The fitter now has only two required arguments: `t_sim` and `mah_sim`.
