### PR TITLE
Refactor DiffmahPop Monte Carlo generators

### DIFF
--- a/diffmah/diffmahpop_kernels/mc_bimod_cens.py
+++ b/diffmah/diffmahpop_kernels/mc_bimod_cens.py
@@ -273,7 +273,7 @@ def mc_diffmah_cenpop(diffmahpop_params, lgm_obs, t_obs, ran_key, lgt0, t_peak=N
     mc_early = uran < frac_early_cens
     _p = [jnp.where(mc_early, x, y) for x, y in zip(mah_params_early, mah_params_late)]
     mah_params = DEFAULT_MAH_PARAMS._make(_p)
-    return mah_params, mah_params_early, mah_params_late, frac_early_cens
+    return mah_params, mah_params_early, mah_params_late, frac_early_cens, mc_early
 
 
 @jjit

--- a/diffmah/diffmahpop_kernels/mc_bimod_cens.py
+++ b/diffmah/diffmahpop_kernels/mc_bimod_cens.py
@@ -48,6 +48,21 @@ def _mean_diffmah_params(diffmahpop_params, lgm_obs, t_obs, ran_key, lgt0):
 
 
 @jjit
+def _mean_diffmah_params_t_peak(diffmahpop_params, lgm_obs, t_obs, t_peak, ran_key):
+    mah_params_early = _mean_diffmah_params_early_t_peak(
+        diffmahpop_params, lgm_obs, t_obs, t_peak, ran_key
+    )
+
+    mah_params_late = _mean_diffmah_params_late_t_peak(
+        diffmahpop_params, lgm_obs, t_obs, t_peak, ran_key
+    )
+
+    frac_early_cens = _frac_early_cens_kern(diffmahpop_params, lgm_obs, t_obs)
+
+    return mah_params_early, mah_params_late, frac_early_cens
+
+
+@jjit
 def _mean_diffmah_params_early(diffmahpop_params, lgm_obs, t_obs, ran_key, lgt0):
     t_0 = 10**lgt0
     model_params = get_component_model_params(diffmahpop_params)
@@ -66,6 +81,35 @@ def _mean_diffmah_params_early(diffmahpop_params, lgm_obs, t_obs, ran_key, lgt0)
     tpc_key, ran_key = jran.split(ran_key, 2)
 
     t_peak = mc_tpeak_singlecen(tp_pdf_cens_params, lgm_obs, t_obs, tpc_key, t_0)
+
+    logm0 = _pred_logm0_kern_early(logm0_params, lgm_obs, t_obs, t_peak)
+    logtc = _pred_logtc_early(logtc_params, lgm_obs, t_obs, t_peak)
+    early_index = _pred_early_index_early(early_index_params, lgm_obs, t_obs, t_peak)
+    late_index = _pred_late_index_early(late_index_params, lgm_obs)
+
+    mah_params = DiffmahParams(logm0, logtc, early_index, late_index, t_peak)
+
+    return mah_params
+
+
+@jjit
+def _mean_diffmah_params_early_t_peak(
+    diffmahpop_params, lgm_obs, t_obs, t_peak, ran_key
+):
+    model_params = get_component_model_params(diffmahpop_params)
+    (
+        tp_pdf_cens_params,
+        tp_pdf_sats_params,
+        logm0_params,
+        logm0_sats_params,
+        logtc_params,
+        early_index_params,
+        late_index_params,
+        fec_params,
+        cov_params,
+    ) = model_params
+
+    tpc_key, ran_key = jran.split(ran_key, 2)
 
     logm0 = _pred_logm0_kern_early(logm0_params, lgm_obs, t_obs, t_peak)
     logtc = _pred_logtc_early(logtc_params, lgm_obs, t_obs, t_peak)
@@ -108,8 +152,45 @@ def _mean_diffmah_params_late(diffmahpop_params, lgm_obs, t_obs, ran_key, lgt0):
 
 
 @jjit
-def mc_diffmah_params_singlecen(diffmahpop_params, lgm_obs, t_obs, ran_key, lgt0):
-    _res = _mean_diffmah_params(diffmahpop_params, lgm_obs, t_obs, ran_key, lgt0)
+def _mean_diffmah_params_late_t_peak(
+    diffmahpop_params, lgm_obs, t_obs, t_peak, ran_key
+):
+    model_params = get_component_model_params(diffmahpop_params)
+    (
+        tp_pdf_cens_params,
+        tp_pdf_sats_params,
+        logm0_params,
+        logm0_sats_params,
+        logtc_params,
+        early_index_params,
+        late_index_params,
+        fec_params,
+        cov_params,
+    ) = model_params
+
+    tpc_key, ran_key = jran.split(ran_key, 2)
+
+    logm0 = _pred_logm0_kern_late(logm0_params, lgm_obs, t_obs, t_peak)
+    logtc = _pred_logtc_late(logtc_params, lgm_obs, t_obs, t_peak)
+    early_index = _pred_early_index_late(early_index_params, lgm_obs, t_obs, t_peak)
+    late_index = _pred_late_index_late(late_index_params, lgm_obs)
+
+    mah_params = DiffmahParams(logm0, logtc, early_index, late_index, t_peak)
+
+    return mah_params
+
+
+@jjit
+def mc_diffmah_params_singlecen(
+    diffmahpop_params, lgm_obs, t_obs, ran_key, lgt0, t_peak=None
+):
+    if t_peak is None:
+        _res = _mean_diffmah_params(diffmahpop_params, lgm_obs, t_obs, ran_key, lgt0)
+    else:
+        _res = _mean_diffmah_params_t_peak(
+            diffmahpop_params, lgm_obs, t_obs, t_peak, ran_key
+        )
+
     (
         mean_mah_params_early,
         mean_mah_params_late,

--- a/diffmah/diffmahpop_kernels/mc_bimod_sats.py
+++ b/diffmah/diffmahpop_kernels/mc_bimod_sats.py
@@ -269,7 +269,7 @@ def mc_diffmah_satpop(diffmahpop_params, lgm_obs, t_obs, ran_key, lgt0, t_peak=N
     mc_early = uran < frac_early_cens
     _p = [jnp.where(mc_early, x, y) for x, y in zip(mah_params_early, mah_params_late)]
     mah_params = DEFAULT_MAH_PARAMS._make(_p)
-    return mah_params, mah_params_early, mah_params_late, frac_early_cens
+    return mah_params, mah_params_early, mah_params_late, frac_early_cens, mc_early
 
 
 @jjit

--- a/diffmah/diffmahpop_kernels/tests/test_mc_diffmahpop_bimod_cens.py
+++ b/diffmah/diffmahpop_kernels/tests/test_mc_diffmahpop_bimod_cens.py
@@ -70,6 +70,34 @@ def test_mc_diffmah_params_singlecen():
         assert np.all(np.isfinite(mah_params_l.logtc))
 
 
+def test_mc_diffmah_params_singlecen_agrees_with_fixed_t_peak_version():
+    ran_key = jran.key(0)
+    t_0 = 13.0
+    lgt0 = np.log10(t_0)
+    t_obs = 10.0
+    lgmarr = np.linspace(10, 15, 20)
+    for lgm_obs in lgmarr:
+        args = (DEFAULT_DIFFMAHPOP_PARAMS, lgm_obs, t_obs, ran_key, lgt0)
+        _res = mcdpk.mc_diffmah_params_singlecen(*args)
+        mah_params_e, mah_params_l, frac_early = _res
+
+        _res2 = mcdpk.mc_diffmah_params_singlecen(
+            *args,
+            t_peak=mah_params_e.t_peak,
+        )
+        mah_params_e2, mah_params_l2, frac_early2 = _res2
+        for p, p2 in zip(mah_params_e, mah_params_e2):
+            assert np.allclose(p, p2)
+
+        _res3 = mcdpk.mc_diffmah_params_singlecen(
+            *args,
+            t_peak=mah_params_l.t_peak,
+        )
+        mah_params_e3, mah_params_l3, frac_early3 = _res3
+        for p, p2 in zip(mah_params_l, mah_params_l3):
+            assert np.allclose(p, p2)
+
+
 def test_predict_mah_moments_singlebin():
     ran_key = jran.key(0)
     t_0 = 13.0

--- a/diffmah/diffmahpop_kernels/tests/test_mc_diffmahpop_bimod_cens.py
+++ b/diffmah/diffmahpop_kernels/tests/test_mc_diffmahpop_bimod_cens.py
@@ -111,13 +111,13 @@ def test_mc_diffmah_cenpop():
 
     args = DEFAULT_DIFFMAHPOP_PARAMS, lgm_obs, t_obs, ran_key, lgt0
     _res = mcdpk.mc_diffmah_cenpop(*args)
-    mah_params, mah_params_early, mah_params_late, frac_early_cens = _res
+    mah_params, mah_params_early, mah_params_late, frac_early_cens, mc_early = _res
     for x in mah_params:
         assert x.shape == (n_halos,)
         assert np.all(np.isfinite(x))
 
     _res = mcdpk.mc_diffmah_cenpop(*args, t_peak=t_peak)
-    mah_params, mah_params_early, mah_params_late, frac_early_cens = _res
+    mah_params, mah_params_early, mah_params_late, frac_early_cens, mc_early = _res
     for x in mah_params:
         assert x.shape == (n_halos,)
         assert np.all(np.isfinite(x))

--- a/diffmah/diffmahpop_kernels/tests/test_mc_diffmahpop_bimod_cens.py
+++ b/diffmah/diffmahpop_kernels/tests/test_mc_diffmahpop_bimod_cens.py
@@ -98,6 +98,31 @@ def test_mc_diffmah_params_singlecen_agrees_with_fixed_t_peak_version():
             assert np.allclose(p, p2)
 
 
+def test_mc_diffmah_cenpop():
+    ran_key = jran.key(0)
+    t_0 = 13.0
+    lgt0 = np.log10(t_0)
+
+    n_halos = 450
+    lgm_key, t_obs_key, t_peak_key, ran_key = jran.split(ran_key, 4)
+    lgm_obs = jran.uniform(lgm_key, minval=10, maxval=15, shape=(n_halos,))
+    t_obs = jran.uniform(t_obs_key, minval=2, maxval=15, shape=(n_halos,))
+    t_peak = jran.uniform(t_obs_key, minval=2, maxval=15, shape=(n_halos,))
+
+    args = DEFAULT_DIFFMAHPOP_PARAMS, lgm_obs, t_obs, ran_key, lgt0
+    _res = mcdpk.mc_diffmah_cenpop(*args)
+    mah_params, mah_params_early, mah_params_late, frac_early_cens = _res
+    for x in mah_params:
+        assert x.shape == (n_halos,)
+        assert np.all(np.isfinite(x))
+
+    _res = mcdpk.mc_diffmah_cenpop(*args, t_peak=t_peak)
+    mah_params, mah_params_early, mah_params_late, frac_early_cens = _res
+    for x in mah_params:
+        assert x.shape == (n_halos,)
+        assert np.all(np.isfinite(x))
+
+
 def test_predict_mah_moments_singlebin():
     ran_key = jran.key(0)
     t_0 = 13.0

--- a/diffmah/diffmahpop_kernels/tests/test_mc_diffmahpop_bimod_sats.py
+++ b/diffmah/diffmahpop_kernels/tests/test_mc_diffmahpop_bimod_sats.py
@@ -56,7 +56,7 @@ def test_mean_diffmah_params():
             assert np.all(np.isfinite(_x))
 
 
-def test_mc_diffmah_params_singlecen():
+def test_mc_diffmah_params_singlesat():
     ran_key = jran.key(0)
     t_0 = 13.0
     lgt0 = np.log10(t_0)
@@ -64,10 +64,32 @@ def test_mc_diffmah_params_singlecen():
     lgmarr = np.linspace(10, 15, 20)
     for lgm_obs in lgmarr:
         args = (DEFAULT_DIFFMAHPOP_PARAMS, lgm_obs, t_obs, ran_key, lgt0)
-        _res = mcdpk.mc_diffmah_params_singlecen(*args)
+        _res = mcdpk.mc_diffmah_params_singlesat(*args)
         mah_params_e, mah_params_l, frac_early = _res
         assert np.all(np.isfinite(mah_params_e.logtc))
         assert np.all(np.isfinite(mah_params_l.logtc))
+
+
+def test_mc_diffmah_params_singlesat_agrees_with_fixed_t_peak_version():
+    ran_key = jran.key(0)
+    t_0 = 13.0
+    lgt0 = np.log10(t_0)
+    t_obs = 10.0
+    lgmarr = np.linspace(10, 15, 20)
+    for lgm_obs in lgmarr:
+        args = (DEFAULT_DIFFMAHPOP_PARAMS, lgm_obs, t_obs, ran_key, lgt0)
+        _res = mcdpk.mc_diffmah_params_singlesat(*args)
+        mah_params_e, mah_params_l, frac_early = _res
+
+        _res2 = mcdpk.mc_diffmah_params_singlesat(*args, t_peak=mah_params_e.t_peak)
+        mah_params_e2, mah_params_l2, frac_early2 = _res2
+        for p, p2 in zip(mah_params_e, mah_params_e2):
+            assert np.allclose(p, p2)
+
+        _res3 = mcdpk.mc_diffmah_params_singlesat(*args, t_peak=mah_params_l.t_peak)
+        mah_params_e3, mah_params_l3, frac_early3 = _res3
+        for p, p2 in zip(mah_params_l, mah_params_l3):
+            assert np.allclose(p, p2)
 
 
 def test_predict_mah_moments_singlebin():

--- a/diffmah/diffmahpop_kernels/tests/test_mc_diffmahpop_bimod_sats.py
+++ b/diffmah/diffmahpop_kernels/tests/test_mc_diffmahpop_bimod_sats.py
@@ -185,13 +185,13 @@ def test_mc_diffmah_satpop():
 
     args = DEFAULT_DIFFMAHPOP_PARAMS, lgm_obs, t_obs, ran_key, lgt0
     _res = mcdpk.mc_diffmah_satpop(*args)
-    mah_params, mah_params_early, mah_params_late, frac_early_cens = _res
+    mah_params, mah_params_early, mah_params_late, frac_early_cens, mc_early = _res
     for x in mah_params:
         assert x.shape == (n_halos,)
         assert np.all(np.isfinite(x))
 
     _res = mcdpk.mc_diffmah_satpop(*args, t_peak=t_peak)
-    mah_params, mah_params_early, mah_params_late, frac_early_cens = _res
+    mah_params, mah_params_early, mah_params_late, frac_early_cens, mc_early = _res
     for x in mah_params:
         assert x.shape == (n_halos,)
         assert np.all(np.isfinite(x))

--- a/diffmah/diffmahpop_kernels/tests/test_mc_diffmahpop_bimod_sats.py
+++ b/diffmah/diffmahpop_kernels/tests/test_mc_diffmahpop_bimod_sats.py
@@ -170,3 +170,28 @@ def test_mc_satpop():
     dmhdt_recomputed, log_mah_recomputed = dk.mah_halopop(mah_params, tarr, LGT0)
     assert np.allclose(dmhdt, dmhdt_recomputed)
     assert np.allclose(log_mah, log_mah_recomputed)
+
+
+def test_mc_diffmah_satpop():
+    ran_key = jran.key(0)
+    t_0 = 13.0
+    lgt0 = np.log10(t_0)
+
+    n_halos = 450
+    lgm_key, t_obs_key, t_peak_key, ran_key = jran.split(ran_key, 4)
+    lgm_obs = jran.uniform(lgm_key, minval=10, maxval=15, shape=(n_halos,))
+    t_obs = jran.uniform(t_obs_key, minval=2, maxval=15, shape=(n_halos,))
+    t_peak = jran.uniform(t_obs_key, minval=2, maxval=15, shape=(n_halos,))
+
+    args = DEFAULT_DIFFMAHPOP_PARAMS, lgm_obs, t_obs, ran_key, lgt0
+    _res = mcdpk.mc_diffmah_satpop(*args)
+    mah_params, mah_params_early, mah_params_late, frac_early_cens = _res
+    for x in mah_params:
+        assert x.shape == (n_halos,)
+        assert np.all(np.isfinite(x))
+
+    _res = mcdpk.mc_diffmah_satpop(*args, t_peak=t_peak)
+    mah_params, mah_params_early, mah_params_late, frac_early_cens = _res
+    for x in mah_params:
+        assert x.shape == (n_halos,)
+        assert np.all(np.isfinite(x))


### PR DESCRIPTION
Previously, the only API to the DiffmahPop generators required MC generation of `t_peak`. But in some use-cases, one wants to use the value of `t_peak` taken from the simulation, and to generate the remaining diffmah parameters conditioned on the simulated `t_peak` (and conditioned on `logmp`, the halo mass at that time). This PR refactors the internal kernels of DiffmahPop to provide two new MC generators that support this use-case: `mc_diffmah_cenpop` and `mc_diffmah_satpop`. There are no changes to the API or behavior of previous functions.