### PR TITLE
Change `t_peak` param bounds from `0.5 < t_peak < 20.0` ==> `0.05 < t_peak < 20.0`

### DIFF
--- a/diffmah/diffmah_kernels.py
+++ b/diffmah/diffmah_kernels.py
@@ -25,7 +25,7 @@ MAH_PBDICT = OrderedDict(
     logtc=(-1.0, 1.0),
     early_index=(0.1, 10.0),
     late_index=(0.1, 5.0),
-    t_peak=(0.5, 20.0),
+    t_peak=(0.05, 20.0),
 )
 MAH_PBOUNDS = DiffmahParams(*list(MAH_PBDICT.values()))
 

--- a/diffmah/diffmahpop_kernels/mc_bimod_cens.py
+++ b/diffmah/diffmahpop_kernels/mc_bimod_cens.py
@@ -192,11 +192,7 @@ def mc_diffmah_params_singlecen(
             diffmahpop_params, lgm_obs, t_obs, t_peak, ran_key
         )
 
-    (
-        mean_mah_params_early,
-        mean_mah_params_late,
-        frac_early_cens,
-    ) = _res
+    mean_mah_params_early, mean_mah_params_late, frac_early_cens = _res
 
     mean_mah_u_params_early = get_unbounded_mah_params(mean_mah_params_early)
     mean_mah_u_params_late = get_unbounded_mah_params(mean_mah_params_late)

--- a/diffmah/diffmahpop_kernels/mc_bimod_sats.py
+++ b/diffmah/diffmahpop_kernels/mc_bimod_sats.py
@@ -192,7 +192,7 @@ def mc_diffmah_params_singlesat(
             diffmahpop_params, lgm_obs, t_obs, t_peak, ran_key
         )
 
-    (mean_mah_params_early, mean_mah_params_late, frac_early_cens) = _res
+    mean_mah_params_early, mean_mah_params_late, frac_early_cens = _res
 
     mean_mah_u_params_early = get_unbounded_mah_params(mean_mah_params_early)
     mean_mah_u_params_late = get_unbounded_mah_params(mean_mah_params_late)

--- a/diffmah/diffmahpop_kernels/t_peak_kernels/tp_pdf_cens_flex.py
+++ b/diffmah/diffmahpop_kernels/t_peak_kernels/tp_pdf_cens_flex.py
@@ -18,6 +18,7 @@ UTP_LGM_X0_K = 1.0
 UTP_T_OBS_X0_K = 2.0
 
 
+# lower bound on t_peak/t_obs
 UTP_MIN = 0.05
 
 DEFAULT_TPCENS_PDICT = OrderedDict(

--- a/diffmah/diffmahpop_kernels/tests/test_mc_diffmahpop_bimod_cens.py
+++ b/diffmah/diffmahpop_kernels/tests/test_mc_diffmahpop_bimod_cens.py
@@ -129,11 +129,11 @@ def test_mc_diffmah_cenpop_holds_t_peak_fixed_correctly():
     t_0 = 13.0
     lgt0 = np.log10(t_0)
 
-    n_halos = 450
+    n_halos = 4_500
     lgm_key, t_obs_key, t_peak_key, ran_key = jran.split(ran_key, 4)
     lgm_obs = jran.uniform(lgm_key, minval=10, maxval=15, shape=(n_halos,))
     t_obs = jran.uniform(t_obs_key, minval=2, maxval=15, shape=(n_halos,))
-    t_peak = jran.uniform(t_obs_key, minval=3, maxval=10, shape=(n_halos,))
+    t_peak = jran.uniform(t_obs_key, minval=0.2, maxval=10, shape=(n_halos,))
 
     args = DEFAULT_DIFFMAHPOP_PARAMS, lgm_obs, t_obs, ran_key, lgt0
     halopop = mcdpk.mc_diffmah_cenpop(*args, t_peak=t_peak)

--- a/diffmah/diffmahpop_kernels/tests/test_mc_diffmahpop_bimod_cens.py
+++ b/diffmah/diffmahpop_kernels/tests/test_mc_diffmahpop_bimod_cens.py
@@ -124,6 +124,23 @@ def test_mc_diffmah_cenpop():
         assert np.all(np.isfinite(x))
 
 
+def test_mc_diffmah_cenpop_holds_t_peak_fixed_correctly():
+    ran_key = jran.key(0)
+    t_0 = 13.0
+    lgt0 = np.log10(t_0)
+
+    n_halos = 450
+    lgm_key, t_obs_key, t_peak_key, ran_key = jran.split(ran_key, 4)
+    lgm_obs = jran.uniform(lgm_key, minval=10, maxval=15, shape=(n_halos,))
+    t_obs = jran.uniform(t_obs_key, minval=2, maxval=15, shape=(n_halos,))
+    t_peak = jran.uniform(t_obs_key, minval=3, maxval=10, shape=(n_halos,))
+
+    args = DEFAULT_DIFFMAHPOP_PARAMS, lgm_obs, t_obs, ran_key, lgt0
+    halopop = mcdpk.mc_diffmah_cenpop(*args, t_peak=t_peak)
+    mah_params, mah_params_early, mah_params_late, frac_early_cens, mc_early = halopop
+    assert np.allclose(t_peak, mah_params.t_peak, atol=0.01)
+
+
 def test_predict_mah_moments_singlebin():
     ran_key = jran.key(0)
     t_0 = 13.0

--- a/diffmah/diffmahpop_kernels/tests/test_mc_diffmahpop_bimod_sats.py
+++ b/diffmah/diffmahpop_kernels/tests/test_mc_diffmahpop_bimod_sats.py
@@ -210,7 +210,7 @@ def test_mc_diffmah_satpop_holds_t_peak_fixed_correctly():
     lgm_key, t_obs_key, t_peak_key, ran_key = jran.split(ran_key, 4)
     lgm_obs = jran.uniform(lgm_key, minval=10, maxval=15, shape=(n_halos,))
     t_obs = jran.uniform(t_obs_key, minval=2, maxval=15, shape=(n_halos,))
-    t_peak = jran.uniform(t_obs_key, minval=3, maxval=10, shape=(n_halos,))
+    t_peak = jran.uniform(t_obs_key, minval=0.2, maxval=10, shape=(n_halos,))
 
     args = DEFAULT_DIFFMAHPOP_PARAMS, lgm_obs, t_obs, ran_key, lgt0
     halopop = mcdpk.mc_diffmah_satpop(*args, t_peak=t_peak)

--- a/diffmah/diffmahpop_kernels/tests/test_mc_diffmahpop_bimod_sats.py
+++ b/diffmah/diffmahpop_kernels/tests/test_mc_diffmahpop_bimod_sats.py
@@ -199,3 +199,20 @@ def test_mc_diffmah_satpop():
     for x in mah_params:
         assert x.shape == (n_halos,)
         assert np.all(np.isfinite(x))
+
+
+def test_mc_diffmah_satpop_holds_t_peak_fixed_correctly():
+    ran_key = jran.key(0)
+    t_0 = 13.0
+    lgt0 = np.log10(t_0)
+
+    n_halos = 450
+    lgm_key, t_obs_key, t_peak_key, ran_key = jran.split(ran_key, 4)
+    lgm_obs = jran.uniform(lgm_key, minval=10, maxval=15, shape=(n_halos,))
+    t_obs = jran.uniform(t_obs_key, minval=2, maxval=15, shape=(n_halos,))
+    t_peak = jran.uniform(t_obs_key, minval=3, maxval=10, shape=(n_halos,))
+
+    args = DEFAULT_DIFFMAHPOP_PARAMS, lgm_obs, t_obs, ran_key, lgt0
+    halopop = mcdpk.mc_diffmah_satpop(*args, t_peak=t_peak)
+    mah_params, mah_params_early, mah_params_late, frac_early_cens, mc_early = halopop
+    assert np.allclose(t_peak, mah_params.t_peak, atol=0.01)


### PR DESCRIPTION
Change diffmah param bounds from `0.5 < t_peak < 20.0` ==> `0.05 < t_peak < 20.0`.

The lower bound on `t_peak>0.05` was causing problems with some simulation analysis, since there are some very rare halos for which `t_peak` is smaller than this. I only noticed this when trying to MC generate diffmah parameters using the directly-simulated values of `t_peak`. This shows up in that case because we unbound and rebound the diffmah parameters during the MC generation process.

The only code in the repo that actually uses the bounding function on `t_peak` is `fitting_helpers.py`, and this module holds `t_peak` fixed to its simulated value, and the quantity that is written to disk is `t_peak`, not `u_t_peak`. So this change should not impact any of our existing fits.