### PR TITLE
Improve docstring to diffmah_fitter

### DIFF
--- a/diffmah/fitting_helpers/diffmah_fitter_helpers.py
+++ b/diffmah/fitting_helpers/diffmah_fitter_helpers.py
@@ -1,6 +1,4 @@
-"""Module implements diffmah_fitter for fitting MAHs with diffmah
-
-"""
+"""Module implements diffmah_fitter for fitting MAHs with diffmah"""
 
 from collections import namedtuple
 from copy import deepcopy
@@ -51,9 +49,11 @@ def diffmah_fitter(
     ----------
     t_sim : array, shape (n_t, )
         Age of the universe in Gyr
+        diffmah_fitter assumes t_sim[-1] corresponds to the age of the universe at z=0
 
     mah_sim : array, shape (n_t, )
         Halo mass in units of Msun/h
+        Note that this input array stores Mhalo(t), not log10(Mhalo(t))
 
     lgm_min : float, optional
         Minimum halo mass to use input halo data in the fitter. Default is -inf.


### PR DESCRIPTION
Revised docstring to `diffmah.fitting_helpers.diffmah_fitter_helpers.diffmah_fitter` now includes two notes:
1. Assumes `t_sim[-1]` corresponds to z=0 age of the universe. In principle this could be relaxed, but not without some explicit tests done on real data.
2. Emphasizes that the input mah array should store `Mh(t)`, not `log10(Mh(t))`