### PR TITLE
Add tpeak_fixed feature to diffmah_fitter

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,3 +1,7 @@
+0.7.2 (unreleased)
+- Include optional keyword argument `tpeak_fixed` to `diffmah_fitter` (https://github.com/ArgonneCPAC/diffmah/pull/168)
+
+
 0.7.1 (2025-03-24)
 ------------------
 - Include convenience function mc_select to choose MC realization of MAH (https://github.com/ArgonneCPAC/diffmah/pull/165)


### PR DESCRIPTION
This PR brings in a new optional keyword argument to `diffmah_fitter` that permits manually specifying the value of `t_peak` assumed by the fitter. The default value is set to `None`, in which case the directly-simulated value of `t_peak` will be used, so there is no change to the behavior of the function for the default value.

This feature simplifies the task of checking the effect of including/excluding the `t_peak` diffmah parameter. Here is an example plot made using this new feature that shows the benefit of the `t_peak` parameter for subhalos with early infall times.

![diffmah_example_fit_no_tpeak](https://github.com/user-attachments/assets/6e99244e-5bfc-4496-a01c-a0f24371579d)
