### PR TITLE
Add force_skip_fit to diffmah_fitter

### DIFF
--- a/diffmah/fitting_helpers/diffmah_fitter_helpers.py
+++ b/diffmah/fitting_helpers/diffmah_fitter_helpers.py
@@ -43,6 +43,7 @@ def diffmah_fitter(
     nstep=200,
     n_warmup=1,
     tpeak_fixed=None,
+    force_skip_fit=False,
 ):
     """Fit simulated MAH with diffmah
 
@@ -77,6 +78,9 @@ def diffmah_fitter(
     tpeak_fixed : float, optional
         Value of t_peak assumed in the fitter.
         Default is None, in which case value in the simulated MAH will be used.
+
+    force_skip_fit : bool, optional
+        If True, fitter will be skipped and default no-fit results will be returned
 
     Returns
     -------
@@ -118,6 +122,8 @@ def diffmah_fitter(
         t_fit_min=t_fit_min,
         tpeak_fixed=tpeak_fixed,
     )
+    skip_fit = skip_fit | force_skip_fit
+
     if skip_fit:
         p_best = np.zeros(len(dk.DEFAULT_MAH_PARAMS)) + NOFIT_FILL
         p_best = dk.DEFAULT_MAH_PARAMS._make(p_best)

--- a/diffmah/fitting_helpers/tests/test_diffmah_fitter_helpers.py
+++ b/diffmah/fitting_helpers/tests/test_diffmah_fitter_helpers.py
@@ -302,3 +302,13 @@ def test_diffmah_fitter_tpeak_fixed_feature():
         loss_fixed_tp = fithelp._mse(log_mah_fit_fixed_tpeak, np.log10(mah_sim))
         epsilon = 0.01
         assert loss < loss_fixed_tp + epsilon
+
+
+def test_force_skip_fit_feature():
+    t_sim = np.linspace(0.1, 13.8, 100)
+    mah_sim = 10 ** np.linspace(1, 14, t_sim.size)
+    fit_results = fithelp.diffmah_fitter(t_sim, mah_sim)
+    assert fit_results.skip_fit is False
+
+    fit_results = fithelp.diffmah_fitter(t_sim, mah_sim, force_skip_fit=True)
+    assert fit_results.skip_fit is True


### PR DESCRIPTION
This optional kwarg simplifies using custom criteria to skip when the fitter is run for a halo