### PR TITLE
Add new user-facing kernel `logmh_at_t_obs`

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,5 +1,6 @@
-0.7.2 (unreleased)
+0.7.3 (2025-05-19)
 - Include optional keyword argument `tpeak_fixed` to `diffmah_fitter` (https://github.com/ArgonneCPAC/diffmah/pull/168)
+- Add new convenience kernel `logmh_at_t_obs` for calculating masses of halos on a lightcone (https://github.com/ArgonneCPAC/diffmah/pull/171)
 
 
 0.7.1 (2025-03-24)

--- a/diffmah/diffmah_kernels.py
+++ b/diffmah/diffmah_kernels.py
@@ -1,5 +1,4 @@
-"""
-"""
+""" """
 
 from collections import OrderedDict, namedtuple
 
@@ -40,6 +39,12 @@ def mah_singlehalo(mah_params, tarr, lgt0):
 def mah_halopop(mah_params, tarr, lgt0):
     dmhdt, log_mah = _diffmah_kern_vmap(mah_params, tarr, lgt0)
     return dmhdt, log_mah
+
+
+@jjit
+def logmh_at_t_obs(mah_params, t_obs, lgt0):
+    logmh_at_t_obs = _log_mah_kern(mah_params, t_obs, lgt0)
+    return logmh_at_t_obs
 
 
 @jjit

--- a/diffmah/diffmah_kernels.py
+++ b/diffmah/diffmah_kernels.py
@@ -31,21 +31,83 @@ MAH_PBOUNDS = DiffmahParams(*list(MAH_PBDICT.values()))
 
 @jjit
 def mah_singlehalo(mah_params, tarr, lgt0):
-    """Calculate MAH of a single halo"""
+    """Calculate MAH of a single halo
+
+    Parameters
+    ----------
+    mah_params : namedtuple
+        mah_params = (logm0, logtc, early_index, late_index, t_peak)
+
+    tarr : array, shape (n_times, )
+        Age of the Universe in Gyr at which to compute the MAH
+
+    lgt0 : float
+        log10 of the z=0 age of the Universe in Gyr
+
+    Returns
+    -------
+    dmdht : array, shape (n_times, )
+        Mass accretion rate in Msun/yr
+
+    log_mah : array, shape (n_times, )
+        log10 of halo mass in Msun
+
+    """
     dmhdt, log_mah = _diffmah_kern(mah_params, tarr, lgt0)
     return dmhdt, log_mah
 
 
 @jjit
 def mah_halopop(mah_params, tarr, lgt0):
-    """Calculate MAHs of a halo population"""
+    """Calculate MAHs of a halo population
+
+    Parameters
+    ----------
+    mah_params : namedtuple of arrays with shape (n_halos, )
+        mah_params = (logm0, logtc, early_index, late_index, t_peak)
+
+    tarr : array, shape (n_times, )
+        Age of the Universe in Gyr at which to compute the MAH
+
+    lgt0 : float
+        log10 of the z=0 age of the Universe in Gyr
+
+    Returns
+    -------
+    dmdht : array, shape (n_halos, n_times)
+        Mass accretion rate in Msun/yr
+
+    log_mah : array, shape (n_halos, n_times)
+        log10 of halo mass in Msun
+
+    """
+
     dmhdt, log_mah = _diffmah_kern_vmap(mah_params, tarr, lgt0)
     return dmhdt, log_mah
 
 
 @jjit
 def logmh_at_t_obs(mah_params, t_obs, lgt0):
-    """Calculate halo mass at a single time"""
+    """Calculate halo mass at a single time
+
+    Parameters
+    ----------
+    mah_params : namedtuple
+        mah_params = (logm0, logtc, early_index, late_index, t_peak)
+        Each tuple entry should be a float or array of shape (n_halos, )
+
+    t_obs : float or array of shape (n_halos, )
+        Age of the Universe in Gyr at which to compute the MAH
+
+    lgt0 : float
+        log10 of the z=0 age of the Universe in Gyr
+
+    Returns
+    -------
+    log_mah : float or array of shape (n_halos, )
+        log10 of halo mass in Msun
+
+    """
     logmh_at_t_obs = _log_mah_kern(mah_params, t_obs, lgt0)
     return logmh_at_t_obs
 

--- a/diffmah/diffmah_kernels.py
+++ b/diffmah/diffmah_kernels.py
@@ -31,18 +31,21 @@ MAH_PBOUNDS = DiffmahParams(*list(MAH_PBDICT.values()))
 
 @jjit
 def mah_singlehalo(mah_params, tarr, lgt0):
+    """Calculate MAH of a single halo"""
     dmhdt, log_mah = _diffmah_kern(mah_params, tarr, lgt0)
     return dmhdt, log_mah
 
 
 @jjit
 def mah_halopop(mah_params, tarr, lgt0):
+    """Calculate MAHs of a halo population"""
     dmhdt, log_mah = _diffmah_kern_vmap(mah_params, tarr, lgt0)
     return dmhdt, log_mah
 
 
 @jjit
 def logmh_at_t_obs(mah_params, t_obs, lgt0):
+    """Calculate halo mass at a single time"""
     logmh_at_t_obs = _log_mah_kern(mah_params, t_obs, lgt0)
     return logmh_at_t_obs
 


### PR DESCRIPTION
New convenience kernel avoids the need to import a private function and/or do custom vmapping when computing `Mhalo(t_obs)` for a population of halos on a lightcone that each have a unique redshift, `z_obs`.