### PR TITLE
TNG units

### DIFF
--- a/diffmah/data_loaders/load_tng_mahs.py
+++ b/diffmah/data_loaders/load_tng_mahs.py
@@ -1,10 +1,10 @@
-"""Module loads mass assembly history data for diffmah
-"""
+"""Module loads mass assembly history data for diffmah"""
 
 import numpy as np
 import os
 
 BEBOP_TNG = "/lcrc/project/halotools/alarcon/data/"
+H_TNG = 0.6774
 
 
 def load_tng_data(data_drn=BEBOP_TNG):
@@ -14,5 +14,6 @@ def load_tng_data(data_drn=BEBOP_TNG):
     log_mahs = _halos["mpeakh"]
     log_mahs = np.maximum.accumulate(log_mahs, axis=1)
     mahs = np.where(log_mahs == 0.0, 0.0, 10**log_mahs)
+    mahs = mahs * (1 / H_TNG)
     assert mahs.max() > 1e5
     return tng_t, mahs


### PR DESCRIPTION
Correcting the units of mass of halo MAHs for TNG, so that the output MAHs are in Msun.

The [documentation in TNG](https://www.tng-project.org/data/docs/specifications/) specifies that the Subfind Subhalos `SubhaloMass` column is in units $[10^{10} M_\odot/h]$, while `SubhaloSFR` is in units $[M_\odot/\text{yr}]$.

The current loader assumes that our TNG halo masses are already in $[M_\odot]$. However, when comparing the SFR-$M_0$ relation using TNG data corrected to the desired units of $[M_\odot]$, we find a systematic bias along the x-axis. This indicates that our saved halo masses are still in $[M_\odot/h]$, rather than $[M_\odot]$.

Therefore, the loader should convert saved TNG halo masses to physical solar masses using: $M[M_\odot] = M_{\rm saved}[M_\odot/h] / h$. This PR makes this change.

<img width="1836" height="1356" alt="tng_units" src="https://github.com/user-attachments/assets/99e3c0dd-14dd-45a9-90a8-6882cad19492" />
